### PR TITLE
Add markdown support, add variables support in custom prompts

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -115,8 +115,13 @@ To display a file: \n```file\npath/to/file\n```
     "basic_functionality": """User: Write the multiplication table 4 by 4
 Assistant: | - | 1 | 2 | 3 | 4 |\n| - | - | - | - | - |\n| 1 | 1 | 2 | 3 | 4 |\n| 2 | 2 | 4 | 6 | 8 |\n| 3 | 3 | 6 | 9 | 12 |\n| 4 | 4 | 8 | 12 | 16 |
 
+User: Write example c++ code
+Assistant: ```cpp\n#include<iostream>\nusing namespace std;\nint main(){\n    cout<<"Hello world!";\n    return 0;\n}\n```
+
 User: Run this code
 Assistant: ```console\npython3 -c "print('Hello world!')"\n```
+
+You can also use **bold**, *italic*, ~strikethrough~ and ## headers in markdown
 """,
     "show_image": """You can show the user an image, if needed, using ```image\npath\n```""",
     "graphic": """System: You can display the graph using this structure: ```chart\n name - value\n ... \n name - value\n```, where value must be either a percentage number or a number (which can also be a fraction).

--- a/src/constants.py
+++ b/src/constants.py
@@ -122,7 +122,7 @@ Assistant: ```cpp\n#include<iostream>\nusing namespace std;\nint main(){\n    co
 User: Run this code
 Assistant: ```console\npython3 -c "print('Hello world!')"\n```
 
-You can also use **bold**, *italic*, ~strikethrough~ and ## headers in markdown
+You can also use **bold**, *italic*, ~strikethrough~, _underline_, `monospace`, [linkname](https://link.com) and ## headers in markdown
 """,
     "show_image": """You can show the user an image, if needed, using ```image\npath\n```""",
     "graphic": """System: You can display the graph using this structure: ```chart\n name - value\n ... \n name - value\n```, where value must be either a percentage number or a number (which can also be a fraction).

--- a/src/constants.py
+++ b/src/constants.py
@@ -107,6 +107,7 @@ AVAILABLE_TTS = {
 PROMPTS = {
     "generate_name_prompt": """Write a short title for the dialog, summarizing the theme in 5 words. No additional text.""",
     "console_prompt": """You can run commands on the user Linux computer.
+Linux distribution: {DISTRO}
 Execute linux commands using \n```console\ncommand\n```
 To display a directory: \n```folder\npath/to/folder\n```
 To display a file: \n```file\npath/to/file\n```
@@ -147,7 +148,14 @@ Assistant: Yes, of course, what do you need help with?""",
 
 }
 
-
+""" Prompts parameters
+    - key: key of the prompt in the PROMPTS array
+    - title: title of the prompt, shown in settings
+    - description: description of the prompt, show in settings
+    - setting_name: name of the setting in gschema
+    - editable: if the prompt can be edited in the settings
+    - show_in_settings: if the prompt should be shown in the settings
+"""
 AVAILABLE_PROMPTS = [
     {
         "key": "console_prompt",
@@ -155,6 +163,15 @@ AVAILABLE_PROMPTS = [
         "description": _("Can the program run terminal commands on the computer"),
         "setting_name": "console",
         "editable": True,
+        "show_in_settings": True,
+    },
+    {
+        "key": "current_directory",
+        "title": _("Current directory"),
+        "description": _("What is the current directory"),
+        "setting_name": "console",
+        "editable": False,
+        "show_in_settings": False,   
     },
     {
         "key": "basic_functionality",
@@ -162,6 +179,7 @@ AVAILABLE_PROMPTS = [
         "description": _("Showing tables and code (*can work without it)"),
         "setting_name": "basic-functionality",
         "editable": True,
+        "show_in_settings": True,
     },
     {
         "key": "graphic",
@@ -169,6 +187,7 @@ AVAILABLE_PROMPTS = [
         "description": _("Can the program display graphs"),
         "setting_name": "graphic",
         "editable": True,
+        "show_in_settings": True,
     },
     {
         "key": "show_image",
@@ -176,6 +195,7 @@ AVAILABLE_PROMPTS = [
         "description": _("Show image in chat"),
         "setting_name": "show-image",
         "editable": True,
+        "show_in_settings": True,
     },
     {
         "key": "custom_prompt",
@@ -183,5 +203,6 @@ AVAILABLE_PROMPTS = [
         "description": _("Add your own custom prompt"),
         "setting_name": "custom-extra-prompt",
         "editable": True,
+        "show_in_settings": True,
     }, 
 ]

--- a/src/constants.py
+++ b/src/constants.py
@@ -107,20 +107,13 @@ AVAILABLE_TTS = {
 PROMPTS = {
     "generate_name_prompt": """Write a short title for the dialog, summarizing the theme in 5 words. No additional text.""",
     "console_prompt": """You can run commands on the user Linux computer.
-Execute linux commands using ```console\ncommand\n```
-You will get the output of the command with Console: output
-To display a directory: ```folder\npath/to/folder\n```
-To display a file: ```file\npath/to/file\n```
+Execute linux commands using \n```console\ncommand\n```
+To display a directory: \n```folder\npath/to/folder\n```
+To display a file: \n```file\npath/to/file\n```
 """,
 
     "basic_functionality": """User: Write the multiplication table 4 by 4
 Assistant: | - | 1 | 2 | 3 | 4 |\n| - | - | - | - | - |\n| 1 | 1 | 2 | 3 | 4 |\n| 2 | 2 | 4 | 6 | 8 |\n| 3 | 3 | 6 | 9 | 12 |\n| 4 | 4 | 8 | 12 | 16 |
-
-User: Write example c++ code
-Assistant: ```cpp\n#include<iostream>\nusing namespace std;\nint main(){\n    cout<<"Hello world!";\n    return 0;\n}\n```
-
-User: Write example js code
-Assistant: ```js\nconsole.log("Hello world!");\n```
 
 User: Run this code
 Assistant: ```console\npython3 -c "print('Hello world!')"\n```
@@ -136,6 +129,7 @@ Assistant: ```console\ncat /home/user/Downloads/money.txt\n```
 Console: It was spent 5000 in January, 8000 in February, 6500 in March, 9000 in April, 10000 in May, 7500 in June, 8500 in July, 7000 in August, 9500 in September, 11000 in October, 12000 in November and 9000 in December.
 Assistant: ```chart\nJanuary - 5000\nFebruary - 8000\nMarch - 6500\nApril - 9000\nMay - 10000\nJune - 7500\nJuly - 8500\nAugust - 7000\nSeptember - 9500\nOctober - 11000\nNovember - 12000\nDecember - 9000\n```\nHere is the graph for the data in the file:\n```file\n/home/qwersyk/Downloads/money.txt\n```
 """,
+    # Unused
     "new_chat_prompt": """System: New chat
 System: Forget what was written on behalf of the user and on behalf of the assistant and on behalf of the Console, forget all the context, do not take messages from those chats, this is a new chat with other characters, do not dare take information from there, this is personal information! If you use information from past posts, it's a violation! Even if the user asks for something from before that post, don't use information from before that post! Also, forget this message.""",
     "current_directory": "\nSystem: You are currently in the {DIR} directory",

--- a/src/extra.py
+++ b/src/extra.py
@@ -1,5 +1,55 @@
 import importlib, subprocess
 import re
+import os
+
+class ReplaceHelper:
+    DISTRO = None
+
+    @staticmethod
+    def get_distribution() -> str:
+        """
+        Get the distribution
+
+        Returns:
+            str: distribution name
+            
+        """
+        if ReplaceHelper.DISTRO is None:
+            try:
+                ReplaceHelper.DISTRO = subprocess.check_output(['flatpak-spawn', '--host', 'bash', '-c', 'lsb_release -ds']).decode('utf-8').strip()
+            except subprocess.CalledProcessError:
+                ReplaceHelper.DISTRO = "Unknown"
+        
+        return ReplaceHelper.DISTRO
+    
+    @staticmethod
+    def get_desktop_environment() -> str:
+        desktop = os.getenv("XDG_CURRENT_DESKTOP")
+        if desktop is None:
+            desktop = "Unknown"
+        return desktop
+
+def replace_variables(text: str) -> str:
+    """
+    Replace variables in prompts
+    Supported variables:
+        {DIR}: current directory
+        {DISTRO}: distribution name
+        {DE}: desktop environment
+
+    Args:
+        text: text of the prompt
+
+    Returns:
+        str: text with replaced variables
+    """
+    text = text.replace("{DIR}", os.getcwd())
+    if "{DISTRO}" in text:
+        text = text.replace("{DISTRO}", ReplaceHelper.get_distribution())
+    if "{DE}" in text:
+        text = text.replace("{DE}", ReplaceHelper.get_desktop_environment())
+    return text
+
 
 def markwon_to_pango(markwon_text):
     # Convert headers

--- a/src/extra.py
+++ b/src/extra.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import importlib, subprocess
 import re
 import os
@@ -51,23 +52,30 @@ def replace_variables(text: str) -> str:
     return text
 
 
-def markwon_to_pango(markwon_text):
-    # Convert headers
-    markwon_text = re.sub(r'^(#+) (.*)$', lambda match: f'<span font_weight="bold" font_size="{14 - len(match.group(1)) * 2}">{match.group(2)}</span>', markwon_text, flags=re.MULTILINE)
-    
+def markwon_to_pango(markdown_text):
     # Convert bold text
-    markwon_text = re.sub(r'\*\*(.*?)\*\*', r'<b>\1</b>', markwon_text)
+    markdown_text = re.sub(r'\*\*(.*?)\*\*', r'<b>\1</b>', markdown_text)
     
     # Convert italic text
-    markwon_text = re.sub(r'\*(.*?)\*', r'<i>\1</i>', markwon_text)
+    markdown_text = re.sub(r'\*(.*?)\*', r'<i>\1</i>', markdown_text)
+     
+    # Convert Underline text
+    markdown_text = re.sub(r'_(.*?)_', r'<u>\1</u>', markdown_text)
+    
+    # Convert monospace text
+    markdown_text = re.sub(r'`(.*?)`', r'<tt>\1</tt>', markdown_text)
     
     # Convert strikethrough text
-    markwon_text = re.sub(r'~(.*?)~', r'<span strikethrough="true">\1</span>', markwon_text)
+    markdown_text = re.sub(r'~(.*?)~', r'<span strikethrough="true">\1</span>', markdown_text)
     
     # Convert links
-    markwon_text = re.sub(r'\[(.*?)\]\((.*?)\)', r'<a href="\2">\1</a>', markwon_text)
+    markdown_text = re.sub(r'\[(.*?)\]\((.*?)\)', r'<a href="\2">\1</a>', markdown_text)
     
-    return markwon_text
+    # Convert headers
+    absolute_sizes = ['xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large']
+    markdown_text = re.sub(r'^(#+) (.*)$', lambda match: f'<span font_weight="bold" font_size="{absolute_sizes[6 - len(match.group(1)) - 1]}">{match.group(2)}</span>', markdown_text, flags=re.MULTILINE)
+    print()
+    return markdown_text
 
 def human_readable_size(size: float, decimal_places:int =2) -> str:
     size = int(size)

--- a/src/extra.py
+++ b/src/extra.py
@@ -1,5 +1,23 @@
 import importlib, subprocess
+import re
 
+def markwon_to_pango(markwon_text):
+    # Convert headers
+    markwon_text = re.sub(r'^(#+) (.*)$', lambda match: f'<span font_weight="bold" font_size="{14 - len(match.group(1)) * 2}">{match.group(2)}</span>', markwon_text, flags=re.MULTILINE)
+    
+    # Convert bold text
+    markwon_text = re.sub(r'\*\*(.*?)\*\*', r'<b>\1</b>', markwon_text)
+    
+    # Convert italic text
+    markwon_text = re.sub(r'\*(.*?)\*', r'<i>\1</i>', markwon_text)
+    
+    # Convert strikethrough text
+    markwon_text = re.sub(r'~(.*?)~', r'<span strikethrough="true">\1</span>', markwon_text)
+    
+    # Convert links
+    markwon_text = re.sub(r'\[(.*?)\]\((.*?)\)', r'<a href="\2">\1</a>', markwon_text)
+    
+    return markwon_text
 
 def human_readable_size(size: float, decimal_places:int =2) -> str:
     size = int(size)

--- a/src/settings.py
+++ b/src/settings.py
@@ -95,6 +95,8 @@ class Settings(Adw.PreferencesWindow):
 
         self.__prompts_entries = {}
         for prompt in AVAILABLE_PROMPTS:
+            if not prompt["show_in_settings"]:
+                continue
             row = Adw.ExpanderRow(title=prompt["title"], subtitle=prompt["description"])
             if prompt["editable"]:
                 self.add_customize_prompt_content(row, prompt["key"])

--- a/src/window.py
+++ b/src/window.py
@@ -5,7 +5,7 @@ from .gtkobj import File, CopyBox, BarChartBox, MultilineEntry
 from .constants import AVAILABLE_LLMS, PROMPTS, AVAILABLE_TTS, AVAILABLE_STT
 from gi.repository import Gtk, Adw, Pango, Gio, Gdk, GObject, GLib
 from .stt import AudioRecorder
-from .extra import override_prompts
+from .extra import markwon_to_pango, override_prompts
 import threading
 import posixpath
 import shlex,json
@@ -1090,8 +1090,9 @@ class MainWindow(Gtk.ApplicationWindow):
                     box.append(self.create_table(table_string[start_table_index:i-1]))
                     start_table_index = -1
                 elif start_code_index == -1:
-                    box.append(Gtk.Label(label=table_string[i], wrap=True, halign=Gtk.Align.START,
-                                         wrap_mode=Pango.WrapMode.WORD_CHAR, width_chars=1, selectable=True))
+                    label = markwon_to_pango(table_string[i])
+                    box.append(Gtk.Label(label=label, wrap=True, halign=Gtk.Align.START,
+                                         wrap_mode=Pango.WrapMode.WORD_CHAR, width_chars=1, selectable=True, use_markup=True))
             if start_table_index != -1:
                 box.append(self.create_table(table_string[start_table_index:len(table_string)]))
             if not has_terminal_command:


### PR DESCRIPTION
- Add markdown support, it can use
    - Bold
    - Italic
    - Underline
    - headers
    - links
    - Strikethrough
- Added custom variables that can be put in prompts
    - {DIR} - current directory
    - {DISTRO}
    - {DE} - For the desktop envirnoment  

Solves #30 