### PR TITLE
Fix multiple issues

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -128,7 +128,7 @@ Assistant: ```cpp\n#include<iostream>\nusing namespace std;\nint main(){\n    co
 User: Run this code
 Assistant: ```console\npython3 -c "print('Hello world!')"\n```
 
-You can also use **bold**, *italic*, ~strikethrough~, _underline_, `monospace`, [linkname](https://link.com) and ## headers in markdown
+You can also use **bold**, *italic*, ~strikethrough~, `monospace`, [linkname](https://link.com) and ## headers in markdown
 """,
     "show_image": """You can show the user an image, if needed, using ```image\npath\n```""",
     "graphic": """System: You can display the graph using this structure: ```chart\n name - value\n ... \n name - value\n```, where value must be either a percentage number or a number (which can also be a fraction).

--- a/src/extra.py
+++ b/src/extra.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import importlib, subprocess
 import re
-import os
+import os, sys
 import xml.dom.minidom
 
 class ReplaceHelper:

--- a/src/extra.py
+++ b/src/extra.py
@@ -108,7 +108,10 @@ def find_module(full_module_name):
 
 
 def install_module(module, path):
-    r = subprocess.check_output(["pip3", "install", "--target", path, module]).decode("utf-8")
+    if find_module("pip") is None:
+        print("Downloading pip...")
+        subprocess.check_output(["bash", "-c", "wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py"])
+    r = subprocess.check_output([sys.executable, "-m", "pip", "install", "--target", path, module]).decode("utf-8")
     return r
 
 def can_escape_sandbox():

--- a/src/extra.py
+++ b/src/extra.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import importlib, subprocess
 import re
 import os
+import xml.dom.minidom
 
 class ReplaceHelper:
     DISTRO = None
@@ -51,17 +52,14 @@ def replace_variables(text: str) -> str:
         text = text.replace("{DE}", ReplaceHelper.get_desktop_environment())
     return text
 
-
 def markwon_to_pango(markdown_text):
+    initial_string = markdown_text
     # Convert bold text
     markdown_text = re.sub(r'\*\*(.*?)\*\*', r'<b>\1</b>', markdown_text)
     
     # Convert italic text
     markdown_text = re.sub(r'\*(.*?)\*', r'<i>\1</i>', markdown_text)
-     
-    # Convert Underline text
-    markdown_text = re.sub(r'_(.*?)_', r'<u>\1</u>', markdown_text)
-    
+         
     # Convert monospace text
     markdown_text = re.sub(r'`(.*?)`', r'<tt>\1</tt>', markdown_text)
     
@@ -74,7 +72,12 @@ def markwon_to_pango(markdown_text):
     # Convert headers
     absolute_sizes = ['xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large']
     markdown_text = re.sub(r'^(#+) (.*)$', lambda match: f'<span font_weight="bold" font_size="{absolute_sizes[6 - len(match.group(1)) - 1]}">{match.group(2)}</span>', markdown_text, flags=re.MULTILINE)
-    print()
+    
+    # Check if the generated text is valid. If not just print it unformatted
+    try:
+        xml.dom.minidom.parseString(markdown_text)
+    except Exception as _:
+        return initial_string 
     return markdown_text
 
 def human_readable_size(size: float, decimal_places:int =2) -> str:

--- a/src/llm.py
+++ b/src/llm.py
@@ -576,8 +576,12 @@ class OpenAIHandler(LLMHandler):
         from openai import OpenAI
         messages = self.convert_history(history, system_prompt)
         messages.append({"role": "user", "content": prompt})
+        api = self.get_setting("api")
+        if api == "":
+            api = "nokey"
+        
         client = OpenAI(
-            api_key=self.get_setting("api"),
+            api_key=api,
             base_url=self.get_setting("endpoint")
         )
         try:
@@ -598,8 +602,11 @@ class OpenAIHandler(LLMHandler):
         from openai import OpenAI
         messages = self.convert_history(history, system_prompt)
         messages.append({"role": "user", "content": prompt})
+        api = self.get_setting("api")
+        if api == "":
+            api = "nokey"
         client = OpenAI(
-            api_key=self.get_setting("api"),
+            api_key=api,
             base_url=self.get_setting("endpoint")
         )
         try:

--- a/src/presentation.py
+++ b/src/presentation.py
@@ -89,36 +89,36 @@ class PresentationWindow(Adw.Window):
         settings = Settings(self.app, headless=True)
         pages = [
             {
-                "title": "Welcome to Newelle",
-                "description": "Your ultimate virtual assistant.",
+                "title": _("Welcome to Newelle"),
+                "description": _("Your ultimate virtual assistant."),
                 "picture": "/io/github/qwersyk/Newelle/images/illustration.svg",
                 "actions": [
                     {
-                        "label": "Github Page",
+                        "label": _("Github Page"),
                         "classes": [],
                         "callback": lambda x: subprocess.Popen(["xdg-open", "https://github.com/qwersyk/Newelle"]), 
                     }
                 ]
             },
             {
-                "title": "Choose your favourite AI Language Model",
-                "description": "Newelle can be used with mutiple models and providers!\n<b>Note: It is strongly suggested to read the Guide to LLM page</b>",
+                "title": _("Choose your favourite AI Language Model"),
+                "description": _("Newelle can be used with mutiple models and providers!\n<b>Note: It is strongly suggested to read the Guide to LLM page</b>"),
                 "widget": self.__steal_from_settings(settings.LLM),
                 "actions": [
                     {
-                        "label": "Guide to LLM",
+                        "label": _("Guide to LLM"),
                         "classes": ["suggested-action"],
                         "callback": lambda x: subprocess.Popen(["xdg-open", "https://github.com/qwersyk/Newelle/wiki/User-guide-to-the-available-LLMs"]),
                     }
                 ] 
             },
             {
-                "title": "Extensions",
-                "description": "You can extend Newelle's functionalities using extensions!",
+                "title": _("Extensions"),
+                "description": _("You can extend Newelle's functionalities using extensions!"),
                 "picture": "/io/github/qwersyk/Newelle/images/extension.svg",
                 "actions": [
                     {
-                        "label": "Download extensions",
+                        "label": _("Download extensions"),
                         "classes": ["suggested-action"],
                         "callback": lambda x: subprocess.Popen(["xdg-open", "https://github.com/topics/newelle-extension"]),
                     }
@@ -128,8 +128,8 @@ class PresentationWindow(Adw.Window):
         # Show the warning only if there are not enough permissions
         if not can_escape_sandbox():
             pages.append({
-                "title": "Permission Error",
-                "description": "Newelle does not have enough permissions to run commands on your system.",
+                "title": _("Permission Error"),
+                "description": _("Newelle does not have enough permissions to run commands on your system."),
                 "picture": "/io/github/qwersyk/Newelle/images/error.svg",
                 "actions": [
                     {
@@ -140,12 +140,12 @@ class PresentationWindow(Adw.Window):
                 ]
             })
         pages.append({
-                "title": "Begin using the app",
+                "title": _("Begin using the app"),
                 "description": None,
                 "widget":self.__create_icon("emblem-default-symbolic"),
                 "actions": [
                     {
-                        "label": "Start chatting",
+                        "label": _("Start chatting"),
                         "classes": ["suggested-action"],
                         "callback": self.close_window,
                     }

--- a/src/settings.py
+++ b/src/settings.py
@@ -245,11 +245,11 @@ class Settings(Adw.PreferencesWindow):
 
         Returns: AVAILABLE_LLMS, AVAILABLE_STT, AVAILABLE_TTS based on the type of the handler 
         """
-        if type(handler) is TTSHandler:
+        if issubclass(type(handler), TTSHandler):
             return AVAILABLE_TTS
-        elif type(handler) is STTHandler:
+        elif issubclass(type(handler), STTHandler):
             return AVAILABLE_STT
-        elif type(handler) is LLMHandler:
+        elif issubclass(type(handler), LLMHandler):
             return AVAILABLE_LLMS
         else:
             raise Exception("Unknown handler")
@@ -413,6 +413,7 @@ class Settings(Adw.PreferencesWindow):
         Popen(["flatpak-spawn", "--host", "xdg-open", button.get_name()])
 
     def on_setting_change(self, constants: dict[str, Any], handler: LLMHandler | TTSHandler | STTHandler, key: str, force_change : bool = False):
+        
         if not force_change:
             setting_info = [info for info in handler.get_extra_settings() if info["key"] == key][0]
         if force_change or "update_settings" in setting_info and setting_info["update_settings"]:

--- a/src/settings.py
+++ b/src/settings.py
@@ -173,7 +173,7 @@ class Settings(Adw.PreferencesWindow):
         # Add check button
         button = Gtk.CheckButton(name=key, group=group, active=active)
         button.connect("toggled", self.choose_row, constants)
-        if not self.sandbox and handler.requires_sandbox_escape():
+        if not self.sandbox and handler.requires_sandbox_escape() or not handler.is_installed():
             button.set_sensitive(False)
         row.add_prefix(button)
         return row
@@ -322,8 +322,8 @@ class Settings(Adw.PreferencesWindow):
                 r = Adw.ActionRow(title=setting["title"], subtitle=setting["description"], valign=Gtk.Align.CENTER)
                 box = Gtk.Box()
                 scale = Gtk.Scale(name=setting["key"], round_digits=setting["round-digits"])
-                scale.set_value(float(handler.get_setting(setting["key"])))
-                scale.set_range(setting["min"], setting["max"])
+                scale.set_range(setting["min"], setting["max"]) 
+                scale.set_value(round(handler.get_setting(setting["key"]), setting["round-digits"]))
                 scale.set_size_request(120, -1)
                 scale.connect("change-value", self.setting_change_scale, constants, handler)
                 label = Gtk.Label(label=handler.get_setting(setting["key"]))
@@ -412,9 +412,10 @@ class Settings(Adw.PreferencesWindow):
     def open_website(self, button):
         Popen(["flatpak-spawn", "--host", "xdg-open", button.get_name()])
 
-    def on_setting_change(self, constants: dict[str, Any], handler: LLMHandler | TTSHandler | STTHandler, key: str):
-        setting_info = [info for info in handler.get_extra_settings() if info["key"] == key][0]
-        if "update_settings" in setting_info and setting_info["update_settings"]:
+    def on_setting_change(self, constants: dict[str, Any], handler: LLMHandler | TTSHandler | STTHandler, key: str, force_change : bool = False):
+        if not force_change:
+            setting_info = [info for info in handler.get_extra_settings() if info["key"] == key][0]
+        if force_change or "update_settings" in setting_info and setting_info["update_settings"]:
             # remove all the elements in the specified expander row 
             row = self.settingsrows[(handler.key, self.convert_constants(constants))]["row"]
             setting_list = self.settingsrows[(handler.key, self.convert_constants(constants))]["extra_settings"]
@@ -536,6 +537,8 @@ class Settings(Adw.PreferencesWindow):
             model (): a handler instance
         """
         model.install()
+        if model.is_installed():
+            self.on_setting_change(self.get_constants_from_object(model), model, "", True)
         button.set_child(None)
         button.set_sensitive(False)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -173,6 +173,7 @@ class Settings(Adw.PreferencesWindow):
         # Add check button
         button = Gtk.CheckButton(name=key, group=group, active=active)
         button.connect("toggled", self.choose_row, constants)
+        self.settingsrows[(key, self.convert_constants(constants))]["button"] = button 
         if not self.sandbox and handler.requires_sandbox_escape() or not handler.is_installed():
             button.set_sensitive(False)
         row.add_prefix(button)
@@ -527,6 +528,7 @@ class Settings(Adw.PreferencesWindow):
         """
         spinner = Gtk.Spinner(spinning=True)
         button.set_child(spinner)
+        button.set_sensitive(False)
         t = threading.Thread(target=self.install_model_async, args= (button, handler))
         t.start()
 
@@ -542,7 +544,9 @@ class Settings(Adw.PreferencesWindow):
             self.on_setting_change(self.get_constants_from_object(model), model, "", True)
         button.set_child(None)
         button.set_sensitive(False)
-
+        checkbutton = self.settingsrows[(model.key, self.convert_constants(self.get_constants_from_object(model)))]["button"]
+        checkbutton.set_sensitive(True)
+    
     def refresh_models(self, action):
         """Refresh local models for LLM
 

--- a/src/tts.py
+++ b/src/tts.py
@@ -226,6 +226,3 @@ class CustomTTSHandler(TTSHandler):
             self._play_lock.acquire()
             check_output(["flatpak-spawn", "--host", "bash", "-c", command.replace("{0}", message)])
             self._play_lock.release()
-
-
-    

--- a/src/window.py
+++ b/src/window.py
@@ -1141,7 +1141,8 @@ class MainWindow(Gtk.ApplicationWindow):
             if self.tts_program in AVAILABLE_TTS:
                 tts = AVAILABLE_TTS[self.tts_program]["class"](self.settings, self.directory)
                 message=re.sub(r"```.*?```", "", message_label, flags=re.DOTALL)
-                if not(not message.strip() or message.isspace() or all(char == '\n' for char in message)):tts.play_audio(message)
+                if not(not message.strip() or message.isspace() or all(char == '\n' for char in message)):
+                    tts.play_audio(message)
 
     def update_message(self, message, label):
         GLib.idle_add(label.set_label, message)


### PR DESCRIPTION
- If the markdown is not converted correctly, the message will just be plain text
- Removed underline since it caused a lot of issues
- Fix gtk scales displaying weirdly
- Fix runtime pip dependency not intalling without sdk
- Now you can't select non installed handlers until they are installed
- Handler settings are refreshed after install
- Solve #70 