### PR TITLE
Add ability to create and switch different assistant profiles

### DIFF
--- a/data/io.github.qwersyk.Newelle.gschema.xml
+++ b/data/io.github.qwersyk.Newelle.gschema.xml
@@ -76,5 +76,11 @@
         <key name="extensions-settings" type="s">
           <default>"{}"</default>
         </key>
+        <key name="profiles" type="s">
+          <default>"{}"</default>
+        </key>
+        <key name="current-profile" type="s">
+          <default>"Assistant"</default>
+        </key>
 	</schema>
 </schemalist>

--- a/src/extra.py
+++ b/src/extra.py
@@ -4,6 +4,8 @@ import re, base64, io
 import os, sys
 import xml.dom.minidom, html
 import json
+from gi.repository import Gio
+
 
 class ReplaceHelper:
     DISTRO = None
@@ -31,6 +33,25 @@ class ReplaceHelper:
         if desktop is None:
             desktop = "Unknown"
         return desktop
+
+def get_settings_dict(settings, blacklisted_keys:list = []):
+    """
+    Return a dictionary containing all settings from a Gio.Settings object.
+    """
+    settings_dict = {}
+    for key in settings.list_keys():
+        if key in blacklisted_keys:
+            continue
+        value = settings.get_value(key)
+        settings_dict[key] = value.unpack()
+    return settings_dict
+
+def restore_settings_from_dict(settings, settings_dict):
+    """
+    Restore settings from a dictionary into a Gio.Settings object.
+    """
+    for key, value in settings_dict.items():
+        settings.set_value(key, Gio.Variant.from_value(value))
 
 def get_spawn_command() -> list:
     """

--- a/src/extra.py
+++ b/src/extra.py
@@ -4,7 +4,7 @@ import re, base64, io
 import os, sys
 import xml.dom.minidom, html
 import json
-from gi.repository import Gio
+from gi.repository import GLib, Gio
 
 
 class ReplaceHelper:
@@ -51,7 +51,9 @@ def restore_settings_from_dict(settings, settings_dict):
     Restore settings from a dictionary into a Gio.Settings object.
     """
     for key, value in settings_dict.items():
-        settings.set_value(key, Gio.Variant.from_value(value))
+        current_value = settings.get_value(key)
+        variant = GLib.Variant(current_value.get_type_string(), value)
+        settings.set_value(key, variant)
 
 def get_spawn_command() -> list:
     """

--- a/src/gtkobj.py
+++ b/src/gtkobj.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import gi, os, subprocess
 
 from gi.repository import Gtk, Pango, Gio, Gdk, GtkSource, GObject, Adw, GLib
@@ -14,6 +15,59 @@ def apply_css_to_widget(widget, css_string):
 
     # Add the provider to the widget's style context
     context.add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+
+
+class ProfileRow(Adw.ActionRow):
+    def __init__(self, profile, picture, selected, add=False, allow_delete=False):
+        super().__init__(height_request=50, width_request=250, use_markup=False, activatable=False)
+        self.profile = profile
+        self.add = add
+        # Set properties
+        self.on_forget_f = lambda _: None
+        self.set_name(profile)
+        self.set_title(profile)
+        # Create prefix widget (GtkOverlay)
+        overlay = Gtk.Overlay(width_request=40)
+        self.add_prefix(overlay)
+
+        # Create avatar widget
+        if add:
+            avatar = Adw.Avatar(size=36, text=profile, icon_name="plus-symbolic")
+        elif picture is not None: 
+            avatar = Adw.Avatar(custom_image=Gdk.Texture.new_from_filename(picture), text=profile, show_initials=True, size=36)
+            avatar.get_last_child().get_last_child().set_icon_size(Gtk.IconSize.NORMAL)
+        else:    
+            avatar = Adw.Avatar(text=profile, show_initials=True, size=36)
+        avatar.set_tooltip_text(_("Select profile"))
+        # Signal handler for avatar clicked
+        overlay.add_overlay(avatar)
+
+        # Create checkmark widget
+        if selected:
+            checkmark = Gtk.Image(focusable=False, halign=Gtk.Align.END, valign=Gtk.Align.END)
+            checkmark.set_from_icon_name("check-plain-symbolic")
+            checkmark.set_pixel_size(11)
+            # Apply style to checkmark
+            checkmark.add_css_class("blue-checkmark")
+            overlay.add_overlay(checkmark)
+
+        if allow_delete:
+            # Create suffix widget (GtkButton)
+            forget_button = Gtk.Button()
+            forget_button.set_icon_name("user-trash-symbolic")
+            forget_button.set_valign(Gtk.Align.CENTER)
+            forget_button.set_tooltip_text("Delete Profile")
+            # Signal handler for forget button clicked
+            forget_button.connect("clicked", self.on_forget)
+            # Apply style to forget button
+            forget_button.add_css_class("circular")
+            self.add_suffix(forget_button)
+
+    def set_on_forget(self, f : Callable):
+        self.on_forget_f = f
+
+    def on_forget(self, widget):
+        self.on_forget_f(self.profile)
 
 
 class File(Gtk.Image):

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,6 +36,7 @@ newelle_sources = [
   'shortcuts.py',
   'thread_editing.py',
   'extension.py',
+  'profile.py',
   'llm.py',
   'tts.py',
   'stt.py',

--- a/src/profile.py
+++ b/src/profile.py
@@ -62,7 +62,6 @@ class ProfileDialog(Adw.PreferencesDialog):
         self.image_filter = Gtk.FileFilter()
         self.image_filter.set_name("Images")
         self.image_filter.add_mime_type("image/*")
-        row.grab_focus()
 
 
     def on_profile_name_changed(self, entry):

--- a/src/profile.py
+++ b/src/profile.py
@@ -1,0 +1,124 @@
+
+import subprocess
+from threading import Thread
+import gi, os
+
+from .extra import get_spawn_command
+
+from .constants import AVAILABLE_LLMS, AVAILABLE_PROMPTS, AVAILABLE_STT, AVAILABLE_TTS, PROMPTS
+from .settings import Settings
+from .extensions import ExtensionLoader
+from gi.repository import Gdk, Gtk, Adw, Gio, GLib, GdkPixbuf
+
+class ProfileDialog(Adw.PreferencesDialog):
+    def __init__(self, parent, profile_settings):
+        super().__init__()
+        self.pic_path = None
+        self.profile_settings = profile_settings
+        self.parent = parent
+        self.profile_name = "Assistant " + str(len(self.profile_settings) + 1)
+
+        self.set_title("Create Profile")
+        self.set_search_enabled(False)
+
+        self.page = Adw.PreferencesPage()
+        self.add(self.page)
+
+        self.avatar_group = Adw.PreferencesGroup()
+        self.page.add(self.avatar_group)
+        self.group = Adw.PreferencesGroup()
+        self.page.add(self.group)
+        self.button_group = Adw.PreferencesGroup()
+        self.page.add(self.button_group)
+
+        # Avatar
+        self.avatar = Adw.Avatar(
+            text=self.profile_name,
+            show_initials=True,
+            size=70,
+        )
+        self.avatar.set_margin_bottom(24)
+
+        # Make avatar clickable
+        click_recognizer = Gtk.GestureClick()
+        click_recognizer.connect("pressed", self.on_avatar_clicked)
+        self.avatar.add_controller(click_recognizer)
+
+        self.avatar_group.add(self.avatar)
+
+        row = Adw.EntryRow(title="Profile Name", text=self.profile_name)
+        row.connect("changed", self.on_profile_name_changed)
+        self.entry = row
+        self.group.add(row)
+
+        # Create Button
+        self.create_button = Gtk.Button(label="Create")
+        self.create_button.add_css_class("suggested-action")
+        self.create_button.connect("clicked", self.on_create_clicked)
+        self.button_group.add(self.create_button)
+
+        # File Filter for image selection
+        self.image_filter = Gtk.FileFilter()
+        self.image_filter.set_name("Images")
+        self.image_filter.add_mime_type("image/*")
+        row.grab_focus()
+
+
+    def on_profile_name_changed(self, entry):
+        """Updates the avatar text when the profile name changes."""
+        profile_name = entry.get_text()
+        self.profile_name = profile_name
+        if profile_name:
+            self.avatar.set_text(profile_name)
+        else:
+            self.avatar.set_text(
+                "Assistant " + str(len(self.profile_settings) + 1)
+            )
+
+    def on_avatar_clicked(self, gesture, n_press, x, y):
+        """Opens the file chooser when the avatar is clicked."""
+        # File Chooser
+        filters = Gio.ListStore.new(Gtk.FileFilter)
+
+        image_filter = Gtk.FileFilter(name="Images", patterns=["*.png", "*.jpg", "*.jpeg", "*.webp"])
+
+        filters.append(image_filter)
+
+        dialog = Gtk.FileDialog(title=_("Set profile picture"),
+                                modal=True,
+                                default_filter=image_filter,
+                                filters=filters)
+        dialog.open(self.parent, None, self.on_file_chosen)
+
+    def on_file_chosen(self, dialog, result):
+        """Handles the selected file from the file chooser."""
+        
+        try:
+            file = dialog.open_finish(result)
+        except Exception as _:
+            return
+        if file is None:
+            return
+        file_path = file.get_path()
+        self.pic_path = file_path
+        texture = Gdk.Texture.new_from_file(file)
+        self.avatar.set_custom_image(
+           texture 
+        )
+        self.avatar.set_show_initials(False)
+        # Gotta do this to make it smaller
+        self.avatar.get_last_child().get_last_child().set_icon_size(Gtk.IconSize.NORMAL)
+
+    def on_create_clicked(self, button):
+        """Handles the create button click."""
+
+        if not self.profile_name:
+            toast = Adw.Toast.new("Please enter a profile name.")
+            self.parent.add_toast(toast)
+            return
+        
+        # Get the custom image from the avatar (if any)
+        
+        self.parent.create_profile(self.profile_name, self.pic_path, {})
+        GLib.idle_add(self.parent.switch_profile, self.profile_name)
+        self.close()

--- a/src/profile.py
+++ b/src/profile.py
@@ -70,6 +70,10 @@ class ProfileDialog(Adw.PreferencesDialog):
 
     def on_profile_name_changed(self, entry):
         """Updates the avatar text when the profile name changes."""
+        if len(entry.get_text()) > 30:
+            self.create_button.grab_focus()
+            entry.set_text(entry.get_text()[:30])
+            return
         profile_name = entry.get_text()
         self.profile_name = profile_name
         if profile_name:

--- a/src/profile.py
+++ b/src/profile.py
@@ -62,7 +62,11 @@ class ProfileDialog(Adw.PreferencesDialog):
         self.image_filter = Gtk.FileFilter()
         self.image_filter.set_name("Images")
         self.image_filter.add_mime_type("image/*")
-
+        
+        g = Adw.PreferencesGroup()
+        warning = Gtk.Label(label=_("The settings of the current profile will be copied into the new one"), wrap=True)
+        g.add(warning)
+        self.page.add(g)
 
     def on_profile_name_changed(self, entry):
         """Updates the avatar text when the profile name changes."""

--- a/src/profile.py
+++ b/src/profile.py
@@ -1,4 +1,5 @@
 
+import shutil
 import subprocess
 from threading import Thread
 import gi, os
@@ -112,13 +113,18 @@ class ProfileDialog(Adw.PreferencesDialog):
     def on_create_clicked(self, button):
         """Handles the create button click."""
 
+        if self.pic_path is not None:
+            path = os.path.join(self.parent.path, "profiles")
+            if not os.path.exists(path):
+                os.makedirs(path)
+            shutil.copy(self.pic_path, os.path.join(path, self.profile_name + ".png"))
+            self.pic_path = os.path.join(path, self.profile_name + ".png")
         if not self.profile_name:
             toast = Adw.Toast.new("Please enter a profile name.")
             self.parent.add_toast(toast)
             return
         
-        # Get the custom image from the avatar (if any)
-        
+        # Get the custom image from the avatar (if any) 
         self.parent.create_profile(self.profile_name, self.pic_path, {})
         GLib.idle_add(self.parent.switch_profile, self.profile_name)
         self.close()

--- a/src/window.py
+++ b/src/window.py
@@ -368,18 +368,6 @@ class MainWindow(Gtk.ApplicationWindow):
     def focus_input(self):
         self.input_panel.input_panel.grab_focus()
 
-    def change_profile(self, profile_name):
-        old_settings = get_settings_dict(self.settings, ["current-profile", "profiles"])
-        self.current_profile = self.settings.get_string("current-profile")
-        self.profile_settings = json.loads(self.settings.get_string("profiles")) 
-        self.profile_settings[self.current_profile]["settings"] = old_settings 
-
-        new_settings = self.profile_settings[profile_name]["settings"]
-        restore_settings_from_dict(self.settings, new_settings)
-        self.settings.set_string("profiles", json.dumps(self.profile_settings)) 
-        self.settings.set_string("current-profile", profile_name)
-        self.update_settings()
-
     def create_profile(self, profile_name, picture=None, settings={}):
         self.profile_settings[profile_name] = {"picture": picture, "settings": settings}
         self.settings.set_string("profiles", json.dumps(self.profile_settings))
@@ -571,10 +559,18 @@ class MainWindow(Gtk.ApplicationWindow):
         if self.current_profile == profile:
             return
         print(f"Switching profile to {profile}")
-        self.current_profile = profile
+
+        old_settings = get_settings_dict(self.settings, ["current-profile", "profiles"])
+        self.profile_settings = json.loads(self.settings.get_string("profiles")) 
+        self.profile_settings[self.current_profile]["settings"] = old_settings 
+
+        new_settings = self.profile_settings[profile]["settings"]
+        restore_settings_from_dict(self.settings, new_settings)
+        self.settings.set_string("profiles", json.dumps(self.profile_settings)) 
         self.settings.set_string("current-profile", profile)
-        self.refresh_profiles_box()
         self.update_settings()
+
+        self.refresh_profiles_box()
 
     def update_settings(self):
         self.profile_settings = json.loads(self.settings.get_string("profiles"))

--- a/src/window.py
+++ b/src/window.py
@@ -1677,7 +1677,7 @@ class MainWindow(Gtk.ApplicationWindow):
                 box.append(label)
             box.set_css_classes(["card", "user"])
         if user == "Assistant":
-            label = Gtk.Label(label=user + ": ", margin_top=10, margin_start=10, margin_bottom=10, margin_end=0,
+            label = Gtk.Label(label=self.current_profile + ": ", margin_top=10, margin_start=10, margin_bottom=10, margin_end=0,
                               css_classes=["warning", "heading"])
             if editable:
                 stack.add_named(label, "label")

--- a/src/window.py
+++ b/src/window.py
@@ -553,6 +553,8 @@ class MainWindow(Gtk.ApplicationWindow):
             popover.hide()
             dialog.present()
             return
+        if self.current_profile != action.profile:
+            popover.hide()
         self.switch_profile(action.profile)
 
     def switch_profile(self, profile: str):

--- a/src/window.py
+++ b/src/window.py
@@ -1680,7 +1680,7 @@ class MainWindow(Gtk.ApplicationWindow):
             box.set_css_classes(["card", "user"])
         if user == "Assistant":
             label = Gtk.Label(label=self.current_profile + ": ", margin_top=10, margin_start=10, margin_bottom=10, margin_end=0,
-                              css_classes=["warning", "heading"])
+                              css_classes=["warning", "heading"], wrap=True, ellipsize=Pango.EllipsizeMode.END)
             if editable:
                 stack.add_named(label, "label")
                 stack.add_named(apply_edit_stack, "edit")

--- a/src/window.py
+++ b/src/window.py
@@ -3,10 +3,12 @@ from warnings import filters
 import gi, os, subprocess
 import pickle
 
+from .profile import ProfileDialog
+
 from .llm import LLMHandler
 
 from .presentation import PresentationWindow
-from .gtkobj import File, CopyBox, BarChartBox, MultilineEntry, apply_css_to_widget
+from .gtkobj import File, CopyBox, BarChartBox, MultilineEntry, ProfileRow, apply_css_to_widget
 from .constants import AVAILABLE_LLMS, AVAILABLE_PROMPTS, PROMPTS, AVAILABLE_TTS, AVAILABLE_STT
 from gi.repository import Gtk, Adw, Pango, Gio, Gdk, GObject, GLib, GdkPixbuf
 from .stt import AudioRecorder
@@ -270,7 +272,8 @@ class MainWindow(Gtk.ApplicationWindow):
         self.regenerate_message_button.connect("clicked", self.regenerate_message)
         self.regenerate_message_button.set_visible(False)
         self.chat_controls_entry_block.append(self.regenerate_message_button)
-
+        self.profiles_box = None
+        self.refresh_profiles_box()
         # Input message box
         input_box = Gtk.Box(halign=Gtk.Align.FILL, margin_start=6, margin_end=6, margin_top=6, margin_bottom=6,
                             spacing=6)
@@ -290,10 +293,6 @@ class MainWindow(Gtk.ApplicationWindow):
         else:
             self.attach_button.set_visible(True)
 
-        # Profiles 
-
-        self.profiles_box = self.get_profiles_box()
-        self.chat_header.pack_start(box)
         # Add screen recording button
         self.screen_record_button = Gtk.Button(
             icon_name="media-record-symbolic",
@@ -346,6 +345,12 @@ class MainWindow(Gtk.ApplicationWindow):
         if not self.settings.get_boolean("welcome-screen-shown"):
             GLib.idle_add(self.show_presentation_window)
 
+    def refresh_profiles_box(self):
+        if self.profiles_box is not None:
+            self.chat_header.remove(self.profiles_box)
+        self.profiles_box = self.get_profiles_box()
+        self.chat_header.pack_start(self.profiles_box)
+
     def init_pip_path(self, path):
         install_module("pip-install-test", self.pip_directory)
         path.append(self.pip_directory)
@@ -378,8 +383,14 @@ class MainWindow(Gtk.ApplicationWindow):
     def create_profile(self, profile_name, picture=None, settings={}):
         self.profile_settings[profile_name] = {"picture": picture, "settings": settings}
         self.settings.set_string("profiles", json.dumps(self.profile_settings))
-        self.settings.set_string("current-profile", profile_name)
-        self.update_settings() 
+
+    def delete_profile(self, profile_name):
+        if profile_name == "Assistant" or profile_name == self.settings.get_string("current-profile"):
+            return
+        del self.profile_settings[profile_name]
+        self.settings.set_string("profiles", json.dumps(self.profile_settings))
+        self.refresh_profiles_box()
+        self.update_settings()
 
     def start_recording(self, button):
         if self.automatic_stt:
@@ -513,18 +524,62 @@ class MainWindow(Gtk.ApplicationWindow):
 
     def get_profiles_box(self):
         box = Gtk.Box()
-        
-        profile_button = Gtk.ToggleButton()
-        avatar = Adw.Avatar(custom_image=self.profile_settings[self.current_profile]["picture"], text=self.current_profile)
+        scroll = Gtk.ScrolledWindow(propagate_natural_width=True, propagate_natural_height=True, hscrollbar_policy=Gtk.PolicyType.NEVER) 
+        profile_button = Gtk.MenuButton() 
+        if self.profile_settings[self.current_profile]["picture"] is not None:
+            avatar = Adw.Avatar(custom_image=Gdk.Texture.new_from_filename(self.profile_settings[self.current_profile]["picture"]), text=self.current_profile, show_initials=True, size=20)
+            avatar.get_last_child().get_last_child().set_icon_size(Gtk.IconSize.NORMAL)
+        else:
+            avatar = Adw.Avatar(text=self.current_profile, show_initials=True, size=20)
         profile_button.set_child(avatar)
         box.append(profile_button)
+
+        profiles = Gtk.ListBox(selection_mode=Gtk.SelectionMode.SINGLE, css_classes=["boxed-list"])
+        for profile in self.profile_settings.keys():
+            account_row = ProfileRow(profile, self.profile_settings[profile]["picture"], self.current_profile == profile, allow_delete=profile != "Assistant" and profile != self.current_profile)
+            profiles.append(account_row)
+            account_row.set_on_forget(self.delete_profile)
+        # Separator
+        separator = Gtk.Separator(sensitive=False, can_focus=False, can_target=False, focus_on_click=False)
+        profiles.append(separator)
+        separator.get_parent().set_sensitive(False)
+        # Add profile row
+        profiles.append(ProfileRow(_("Create new profile"), None, False, add=True, allow_delete=False))
+        
+        # Assign widgets
+        popover = Gtk.Popover(css_classes=["menu"])
+        profiles.set_selection_mode(Gtk.SelectionMode.SINGLE)
+        scroll.set_child(profiles) 
+        popover.set_child(scroll)
+        profile_button.set_popover(popover)
+        profiles.select_row(profiles.get_row_at_index(list(self.profile_settings.keys()).index(self.current_profile)))
+        profiles.connect("row-selected", lambda listbox,action, popover=popover : self.select_profile(listbox, action, popover))
         return box
 
+    def select_profile(self, listbox: Gtk.ListBox, action: ProfileRow, popover : Gtk.Popover):
+        if action is None:
+            return
+        if action.add:
+            dialog = ProfileDialog(self, self.profile_settings)
+            listbox.select_row(listbox.get_row_at_index(list(self.profile_settings.keys()).index(self.current_profile)))
+            popover.hide()
+            dialog.present()
+            return
+        self.switch_profile(action.profile)
+
+    def switch_profile(self, profile: str):
+        if self.current_profile == profile:
+            return
+        print(f"Switching profile to {profile}")
+        self.current_profile = profile
+        self.settings.set_string("current-profile", profile)
+        self.refresh_profiles_box()
+        self.update_settings()
 
     def update_settings(self):
         self.profile_settings = json.loads(self.settings.get_string("profiles"))
         self.current_profile = self.settings.get_string("current-profile")
-        if len(self.profile_settings) == 0:
+        if len(self.profile_settings) == 0 or self.current_profile not in self.profile_settings:
             self.profile_settings[self.current_profile] = {"settings": {}, "picture": None}
 
         self.automatic_stt_status = False


### PR DESCRIPTION
- Added a menu button in the chat headerbar where you can switch and create profiles
- Every profile have different settings, and they are copied at creation from the profile from which you switched
- You can set profile picture and name for every profile
- You can delete profiles (except the base one)
- Assistant name changes based on which profile is selected

Fix #111 