### PR TITLE
Add file support, formalize video support

### DIFF
--- a/src/extra.py
+++ b/src/extra.py
@@ -165,6 +165,44 @@ def extract_image(message: str) -> tuple[str | None, str]:
         text = message
     return img, text
 
+def extract_video(message: str) -> tuple[str | None, str]:
+    """
+    Extract video from message
+
+    Args:
+        message: message string
+
+    Returns:
+        tuple[str, str]: image and text, if no image, image is None 
+    """
+    img = None
+    if message.startswith("```video"):
+        img = message.split("\n")[1]
+        text = message.split("\n")[3:]                    
+        text = "\n".join(text)
+    else:
+        text = message
+    return img, text
+
+def extract_file(message: str) -> tuple[str | None, str]:
+    """
+    Extract file from message
+
+    Args:
+        message: message string
+
+    Returns:
+        tuple[str, str]: file and text, if no file, file is None 
+    """
+    file = None
+    if message.startswith("```file"):
+        file = message.split("\n")[1]
+        text = message.split("\n")[3:]                    
+        text = "\n".join(text)
+    else:
+        text = message
+    return file, text
+
 def quote_string(s):
     if "'" in s:
         return "'" + s.replace("'", "'\\''") + "'"

--- a/src/llm.py
+++ b/src/llm.py
@@ -7,7 +7,7 @@ import json
 import base64
 
 import requests
-from .extra import can_escape_sandbox, convert_history_openai, extract_image, extract_json, find_module, get_streaming_extra_setting, install_module, open_website, get_image_path, get_spawn_command, quote_string
+from .extra import can_escape_sandbox, convert_history_openai, extract_image, extract_json, extract_video, find_module, get_streaming_extra_setting, install_module, open_website, get_image_path, get_spawn_command, quote_string
 from .handler import Handler
 
 class LLMHandler(Handler):
@@ -23,6 +23,13 @@ class LLMHandler(Handler):
     def supports_vision(self) -> bool:
         """ Return if the LLM supports receiving images"""
         return False
+
+    def supports_video_vision(self) -> bool:
+        """ Return if the LLM supports receiving videos"""
+        return False
+    def get_supported_files(self) -> list[str]:
+        """ Return the list of supported files excluding the vision ones"""
+        return []
 
     def stream_enabled(self) -> bool:
         """ Return if the LLM supports token streaming"""
@@ -479,6 +486,10 @@ class GeminiHandler(LLMHandler):
 
     def supports_vision(self) -> bool:
         return True
+    
+    def supports_video_vision(self) -> bool:
+        return True
+
     def is_installed(self) -> bool:
         if find_module("google.generativeai") is None:
             return False
@@ -554,6 +565,8 @@ class GeminiHandler(LLMHandler):
         from google.generativeai import upload_file
         img = None
         image, text = extract_image(message)
+        if image is None:
+            image, text = extract_video(message)
         if image is not None:
             if image.startswith("data:image/jpeg;base64,"):
                 image = image[len("data:image/jpeg;base64,"):]


### PR DESCRIPTION
- Handlers now have two methods:
    - supports_video_vision: if a model supports vision on videos
    - get_supported_files: returns the filter for the supported file formats by that handler (other than vision)
Videos get added with video codeblocks, while files with file codeblocks.
Added specific code to Gemini handler to support the change.
 