### PR TITLE
Add ability to edit history for extensions

### DIFF
--- a/src/extensions.py
+++ b/src/extensions.py
@@ -136,17 +136,17 @@ class NewelleExtension(Handler):
         """
         return None
 
-    def preprocess_history(self, history: list, prompts : list, user_prompt: str) -> tuple[list, list, str]:
+    def preprocess_history(self, history: list, prompts : list) -> tuple[list, list]:
         """
         Called on the history before it is sent to the LLM. History is given in Newelle format
         """
-        return history, prompts, user_prompt
+        return history, prompts
 
-    def postprocess_history(self, history: list, prompts: list, bot_response: str) -> tuple[list, list, str]:
+    def postprocess_history(self, history: list, bot_response: str) -> tuple[list, str]:
         """
         Called on the history after it is received from the LLM. History is given in Newelle format
         """
-        return history, prompts, bot_response
+        return history, bot_response
 
 
 class ExtensionLoader:
@@ -398,18 +398,18 @@ class ExtensionLoader:
             return False
         return True
 
-    def preprocess_history(self, history: list, prompts : list, user_prompt: str) -> tuple[list, list, str]:
+    def preprocess_history(self, history: list, prompts : list) -> tuple[list, list]:
         """
         Called on the history before it is sent to the LLM. History is given in Newelle format
         """
         for extension in self.extensions:
-            history, prompts, user_prompt = extension.preprocess_history(history, prompts, user_prompt)
-        return history, prompts, user_prompt
+            history, prompts = extension.preprocess_history(history, prompts)
+        return history, prompts
 
-    def postprocess_history(self, history: list, prompts: list, bot_response: str) -> tuple[list, list, str]:
+    def postprocess_history(self, history: list, bot_response: str) -> tuple[list, str]:
         """
         Called on the history after it is received from the LLM. History is given in Newelle format
         """
         for extension in self.extensions:
-            history, prompts, bot_response = extension.postprocess_history(history, prompts, bot_response)
-        return history, prompts, bot_response
+            history, bot_response = extension.postprocess_history(history, bot_response)
+        return history, bot_response

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -403,7 +403,10 @@ class ExtensionLoader:
         Called on the history before it is sent to the LLM. History is given in Newelle format
         """
         for extension in self.extensions:
-            history, prompts = extension.preprocess_history(history, prompts)
+            try:
+                history, prompts = extension.preprocess_history(history, prompts)
+            except Exception as e:
+                print(e)
         return history, prompts
 
     def postprocess_history(self, history: list, bot_response: str) -> tuple[list, str]:
@@ -411,5 +414,8 @@ class ExtensionLoader:
         Called on the history after it is received from the LLM. History is given in Newelle format
         """
         for extension in self.extensions:
-            history, bot_response = extension.postprocess_history(history, bot_response)
+            try:
+                history, bot_response = extension.postprocess_history(history, bot_response)
+            except Exception as e:
+                print(e)
         return history, bot_response

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -136,6 +136,19 @@ class NewelleExtension(Handler):
         """
         return None
 
+    def preprocess_history(self, history: list, prompts : list, user_prompt: str) -> tuple[list, list, str]:
+        """
+        Called on the history before it is sent to the LLM. History is given in Newelle format
+        """
+        return history, prompts, user_prompt
+
+    def postprocess_history(self, history: list, prompts: list, bot_response: str) -> tuple[list, list, str]:
+        """
+        Called on the history after it is received from the LLM. History is given in Newelle format
+        """
+        return history, prompts, bot_response
+
+
 class ExtensionLoader:
     """
     Class that loads the extensions
@@ -385,3 +398,18 @@ class ExtensionLoader:
             return False
         return True
 
+    def preprocess_history(self, history: list, prompts : list, user_prompt: str) -> tuple[list, list, str]:
+        """
+        Called on the history before it is sent to the LLM. History is given in Newelle format
+        """
+        for extension in self.extensions:
+            history, prompts, user_prompt = extension.preprocess_history(history, prompts, user_prompt)
+        return history, prompts, user_prompt
+
+    def postprocess_history(self, history: list, prompts: list, bot_response: str) -> tuple[list, list, str]:
+        """
+        Called on the history after it is received from the LLM. History is given in Newelle format
+        """
+        for extension in self.extensions:
+            history, prompts, bot_response = extension.postprocess_history(history, prompts, bot_response)
+        return history, prompts, bot_response

--- a/src/utility/strings.py
+++ b/src/utility/strings.py
@@ -135,3 +135,22 @@ def convert_think_codeblocks(text: str) -> str:
         str: The converted text 
     """
     return text.replace("<think>", "```think").replace("</think>", "```")
+
+def get_edited_messages(history: list, old_history: list) -> list | None:
+    """Get the edited messages from the history
+
+    Args:
+        history (list): The history
+        prompts (list): The prompts
+
+    Returns:
+        list: The edited messages IDs, or None if there are removed messages
+    """
+    if len(history) != len(old_history):
+        return None
+    edited_messages = []
+    for i in range(len(history)):
+        if history[i] != old_history[i]:
+            edited_messages.append(i)
+    return edited_messages
+

--- a/src/window.py
+++ b/src/window.py
@@ -1431,7 +1431,9 @@ class MainWindow(Gtk.ApplicationWindow):
             self.model.install()
             self.update_settings()
         # Set the history for the model
-        self.model.set_history(prompts, self.get_history())
+        history = self.get_history()
+        self.extensionloader.preprocess_history(history, prompts, self.chat[-1]["Message"])
+        self.model.set_history(prompts, history)
         try:
             if self.model.stream_enabled():
                 self.streamed_message = ""
@@ -1459,6 +1461,7 @@ class MainWindow(Gtk.ApplicationWindow):
             return
         
         if self.stream_number_variable == stream_number_variable:
+            history, prompts, message_label = self.extensionloader.postprocess_history(history, prompts, message_label) 
             GLib.idle_add(self.show_message, message_label)
         GLib.idle_add(self.remove_send_button_spinner)
         # Generate chat name 
@@ -1677,7 +1680,7 @@ class MainWindow(Gtk.ApplicationWindow):
                             Gtk.Expander(label="think", child=Gtk.Label(label=chunk.text, wrap=True),css_classes=["toolbar", "osd"], margin_top=10,
                                     margin_start=10,
                                     margin_bottom=10, margin_end=10
-)
+                            )
                         )
                     elif code_language == "image":
                         for i in chunk.text.split("\n"):

--- a/src/window.py
+++ b/src/window.py
@@ -9,6 +9,7 @@ import threading
 import posixpath
 import json
 import base64
+import copy
 
 from gi.repository import Gtk, Adw, Pango, Gio, Gdk, GObject, GLib, GdkPixbuf
 
@@ -27,7 +28,7 @@ from .constants import AVAILABLE_LLMS, AVAILABLE_PROMPTS, PROMPTS, AVAILABLE_TTS
 from .utility import override_prompts
 from .utility.system import get_spawn_command 
 from .utility.pip import install_module
-from .utility.strings import convert_think_codeblocks, markwon_to_pango, remove_markdown
+from .utility.strings import convert_think_codeblocks, get_edited_messages, markwon_to_pango, remove_markdown
 from .utility.replacehelper import replace_variables
 from .utility.profile_settings import get_settings_dict, restore_settings_from_dict
 from .utility.audio_recorder import AudioRecorder
@@ -1281,7 +1282,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.stream_number_variable += 1
         self.chat_stop_button.set_visible(False)
         GLib.idle_add(self.update_button_text)
-        if self.chat[-1]["User"] != "Assistant" or "```console" in self.chat[-1]["Message"]:
+        if len(self.chat) > 0 and (self.chat[-1]["User"] != "Assistant" or "```console" in self.chat[-1]["Message"]):
             for i in range(len(self.chat) - 1, -1, -1):
                 if self.chat[i]["User"] in ["Assistant", "Console"]:
                     self.chat.pop(i)
@@ -1432,16 +1433,27 @@ class MainWindow(Gtk.ApplicationWindow):
             self.update_settings()
         # Set the history for the model
         history = self.get_history()
-        self.extensionloader.preprocess_history(history, prompts, self.chat[-1]["Message"])
+        # Let extensions preprocess the history 
+        old_history = copy.deepcopy(history)
+        old_user_prompt = self.chat[-1]["Message"]
+
+        self.chat, prompts = self.extensionloader.preprocess_history(self.chat, prompts)
+        if len(self.chat) == 0:
+            GLib.idle_add(self.remove_send_button_spinner)
+            GLib.idle_add(self.show_chat)
+            return
+        if self.chat[-1]["Message"] != old_user_prompt:
+            self.reload_message(len(self.chat) - 1)
+
         self.model.set_history(prompts, history)
         try:
             if self.model.stream_enabled():
                 self.streamed_message = ""
                 self.curr_label = ""
                 GLib.idle_add(self.create_streaming_message_label)
-                self.streaming_lable = None
+                self.streaming_label = None
                 message_label = self.model.send_message_stream(self, self.chat[-1]["Message"], self.update_message,
-                                                               [stream_number_variable])
+                                                            [stream_number_variable])
                 try:
                     parent = self.streaming_box.get_parent()
                     if parent is not None: 
@@ -1461,7 +1473,14 @@ class MainWindow(Gtk.ApplicationWindow):
             return
         
         if self.stream_number_variable == stream_number_variable:
-            history, prompts, message_label = self.extensionloader.postprocess_history(history, prompts, message_label) 
+            history, message_label = self.extensionloader.postprocess_history(self.chat, message_label)
+            # Edit messages that require to be updated 
+            edited_messages = get_edited_messages(history, old_history)
+            if edited_messages is None:
+                GLib.idle_add(self.show_chat) 
+            else:
+                for message in edited_messages:
+                    GLib.idle_add(self.reload_message, message)
             GLib.idle_add(self.show_message, message_label)
         GLib.idle_add(self.remove_send_button_spinner)
         # Generate chat name 
@@ -1545,6 +1564,7 @@ class MainWindow(Gtk.ApplicationWindow):
     # Show messages in chat
     def show_chat(self):
         """Show a chat"""
+        self.messages_box = []
         self.last_error_box = None
         if not self.check_streams["chat"]:
             self.check_streams["chat"] = True
@@ -1897,6 +1917,24 @@ class MainWindow(Gtk.ApplicationWindow):
         box.remove(old_message)
         box.append(entry)
 
+    def reload_message(self, message_id: int):
+        """Reload a message
+
+        Args:
+            message_id (int): the id of the message to reload 
+        """
+        if len(self.messages_box) <= message_id:
+            return
+        if self.chat[message_id]["User"] == "Console":
+            return
+        message_box = self.messages_box[message_id+1] # +1 to fix message warning
+        old_label = message_box.get_last_child()
+        if old_label is not None:
+            message_box.remove(old_label)
+            message_box.append(
+                self.show_message(self.chat[message_id]["Message"], id_message=message_id, is_user=self.chat[message_id]["User"] == "User", return_widget=True)
+            )
+
     def apply_edit_message(self, gesture, box: Gtk.Box, apply_edit_stack: Gtk.Stack):
         """Apply edit for a message
 
@@ -1944,6 +1982,7 @@ class MainWindow(Gtk.ApplicationWindow):
         """
         del self.chat[int(gesture.get_name())]
         self.chat_list_block.remove(box.get_parent())
+        self.messages_box.remove(box)
         self.save_chat()
         self.show_chat()
 
@@ -2000,7 +2039,7 @@ class MainWindow(Gtk.ApplicationWindow):
         """
         box = Gtk.Box(css_classes=["card"], margin_top=10, margin_start=10, margin_bottom=10, margin_end=10,
                       halign=Gtk.Align.START)
-        
+        self.messages_box.append(box) 
         # Create edit controls
         if editable:
             apply_edit_stack = self.build_edit_box(box, str(id_message))


### PR DESCRIPTION
Extensions can now read and edit history using preprocess_history and postprocess_history. 
The edit to the messages are done on place if possible.

An example extension that uses these capabilities is 
https://github.com/FrancescoCaracciolo/NewelleExtensions/blob/main/extensions/screenshot.py

That after a tool call is done, it puts the image in the user message in order for vision models to see it.

Fixes #142 
