### PR TITLE
Website reading capability

### DIFF
--- a/src/handlers/llm/groq_handler.py
+++ b/src/handlers/llm/groq_handler.py
@@ -6,7 +6,7 @@ class GroqHandler(OpenAIHandler):
     default_models = (("llama-3.3-70B-versatile", "llama-3.3-70B-versatile" ), ) 
     
     def supports_vision(self) -> bool:
-        return "vision" in self.get_setting("model")
+        return any(x in self.get_setting("model") for x in ["llama-4", "vision"])
 
     def __init__(self, settings, path):
         super().__init__(settings, path)

--- a/src/handlers/rag/llamaindex_handler.py
+++ b/src/handlers/rag/llamaindex_handler.py
@@ -28,7 +28,7 @@ class LlamaIndexHanlder(RAGHandler):
         r = [
             ExtraSettings.ScaleSetting("chunk_size", "Chunk Size", "Split text in chunks of the given size (in tokens). Requires a reindex", 512, 64, 2048, 0), 
             ExtraSettings.ScaleSetting("return_documents", "Documents to return", "Maximum number of documents to return", 3,1,5, 0), 
-            ExtraSettings.ScaleSetting("similarity_threshold", "Similarity of the document to be returned", "Set the percentage similarity of a document to get returned", 0.65,0,1, 2), 
+            ExtraSettings.ScaleSetting("similarity_threshold", "Similarity of the document to be returned", "Set the percentage similarity of a document to get returned", 0.2,0,1, 2), 
             ExtraSettings.ToggleSetting("use_llm", "Secondary LLM", "Use the secondary LLM to improve retrivial", False),
             ExtraSettings.ToggleSetting("subdirectory_on", "Index Only a subdirectory", "Choose only a subdirectory to index. If you already have indexed it, you don't need to re-index", False, update_settings=True), 
         ]

--- a/src/handlers/websearch/searxng.py
+++ b/src/handlers/websearch/searxng.py
@@ -7,7 +7,7 @@ class SearXNGHandler(WebSearchHandler):
 
     def get_extra_settings(self) -> list:
         return [
-            ExtraSettings.EntrySetting("endpoint", "SearXNG Instance", "URL of the instance of SearXNG to query.\nIt is strongly suggested to selfhost your own instance with json mode enabled", "https://search.hbubli.cc"),
+            ExtraSettings.EntrySetting("endpoint", "SearXNG Instance", "URL of the instance of SearXNG to query.\nIt is strongly suggested to selfhost your own instance with json mode enabled", "https://search.nyarchlinux.moe"),
             ExtraSettings.EntrySetting("lang", "Language", "Language for the search results", "en"),
             ExtraSettings.ScaleSetting("results", "Results", "Number of results to consider", 2, 1, 10, 0),
             ExtraSettings.ToggleSetting("scrape", "Instance scraping", "Scrape SearXNG instance if JSON format is not enabled", True),

--- a/src/integrations/website_reader.py
+++ b/src/integrations/website_reader.py
@@ -1,12 +1,20 @@
 from gi.repository import Gtk, GLib, GdkPixbuf
 from ..extensions import NewelleExtension
 from ..ui.widgets import WebsiteButton
-import threading 
+import threading
+from ..utility.message_chunk import get_message_chunks
 from newspaper import Article
+
+CHUNK_SIZE = 512 
+MAX_CONTEXT = 5000
 
 class WebsiteReader(NewelleExtension):
     id = "website-reader"
     name = "Website Reader"
+
+    def __init__(self, pip_path: str, extension_path: str, settings):
+        super().__init__(pip_path, extension_path, settings)
+        self.caches = {}
 
     def get_replace_codeblocks_langs(self) -> list:
         return ["website"]
@@ -21,6 +29,26 @@ class WebsiteReader(NewelleExtension):
                 lines += [line]
         history[-1]["Message"] = "\n".join(lines)
 
+        # Find articles
+        websites = []
+        for message in history:
+            for chunk in get_message_chunks(message["Message"]):
+                if chunk.type == "codeblock" and chunk.lang == "website":
+                    websites.append(chunk.text)
+        docs = []
+        for website in websites:
+            article = self.get_article_content(website)
+            docs.append("-----\nSource: " + website + "\n" + article.text)
+        if sum(len(doc) for doc in docs) < MAX_CONTEXT:
+            prompts += docs
+        elif self.rag is not None:
+            print("Using RAG")
+            rag_docs = ["text:" + doc for doc in docs]
+            index = self.rag.build_index(rag_docs, CHUNK_SIZE)
+            results = index.query(user_message)
+            prompts += ["Content from previous websites:\n" + "\n".join(results)]
+        else:
+            prompts.append("Content from previous websites:\n" + "\n".join(docs)[:MAX_CONTEXT])
         return history, prompts
 
     def get_gtk_widget(self, codeblock: str, lang: str) -> Gtk.Widget | None:
@@ -30,10 +58,22 @@ class WebsiteReader(NewelleExtension):
         threading.Thread(target=self.get_article, args=(button,)).start()
         return button
 
+    def restore_gtk_widget(self, codeblock: str, lang: str) -> Gtk.Widget | None:
+        print("restore")
+        return super().restore_gtk_widget(codeblock, lang)
+
+    def get_article_content(self, url: str):
+        if url in self.caches:
+            return self.caches[url]
+        else:
+            article = Article(url)
+            article.download()
+            article.parse()
+            self.caches[url] = article
+            return article
+
     def get_article(self, button: WebsiteButton):
-        article = Article(button.url)
-        article.download()
-        article.parse()
+        article = self.get_article_content(button.url)
         title = article.title
         favicon = article.meta_favicon
         if not favicon.startswith("http") and not favicon.startswith("https"):
@@ -56,7 +96,7 @@ class WebsiteReader(NewelleExtension):
         try:
             response = requests.get(url, stream=True) #stream = True prevent download the whole file into RAM
             response.raise_for_status()
-            for chunk in response.iter_content(chunk_size=8192): #Load in chunks to avoid consuming too much memory for large files
+            for chunk in response.iter_content(chunk_size=1024): #Load in chunks to avoid consuming too much memory for large files
                 pixbuf_loader.write(chunk)
         except Exception as e:
             print("Exception generating the image: " + str(e))

--- a/src/integrations/website_reader.py
+++ b/src/integrations/website_reader.py
@@ -24,7 +24,11 @@ class WebsiteReader(NewelleExtension):
         lines = []
         for line in user_message.split("\n"):
             if line.startswith("#https://") or line.startswith("#http://"):
-                lines += ["```website", "" + line.lstrip("#"), "```"]
+                # Extract just the URL without the hashtag
+                urlline = line.split("#")[1].split()
+                url = urlline[0]
+                lines += ["```website", url, "```"]
+                lines += [" ".join(urlline[1:])]
             else:
                 lines += [line]
         history[-1]["Message"] = "\n".join(lines)

--- a/src/meson.build
+++ b/src/meson.build
@@ -65,6 +65,7 @@ widgets_sources = [
   'ui/widgets/markuptextview.py',
   'ui/widgets/website.py',
   'ui/widgets/websearch.py',
+  'ui/widgets/thinking.py',
 ]
 
 handler_sources = [

--- a/src/ui/widgets/__init__.py
+++ b/src/ui/widgets/__init__.py
@@ -8,5 +8,6 @@ from .latex import DisplayLatex, LatexCanvas, InlineLatex
 from .markuptextview import MarkupTextView
 from .website import WebsiteButton
 from .websearch import WebSearchWidget
+from .thinking import ThinkingWidget
 
-__all__ = ["ProfileRow", "MultilineEntry", "BarChartBox", "ComboRowHelper", "CopyBox", "File", "DisplayLatex", "LatexCanvas", "MarkupTextView", "InlineLatex",  "WebsiteButton", "WebSearchWidget"]
+__all__ = ["ProfileRow", "MultilineEntry", "BarChartBox", "ComboRowHelper", "CopyBox", "File", "DisplayLatex", "LatexCanvas", "MarkupTextView", "InlineLatex",  "WebsiteButton", "WebSearchWidget", "ThinkingWidget"]

--- a/src/ui/widgets/markuptextview.py
+++ b/src/ui/widgets/markuptextview.py
@@ -3,8 +3,8 @@ import xml.etree.ElementTree as ET
 from .. import apply_css_to_widget
 
 class MarkupTextView(Gtk.TextView):
-    def __init__(self, parent):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.set_wrap_mode(Gtk.WrapMode.WORD)
         self.set_editable(False)
         self.set_cursor_visible(False)

--- a/src/ui/widgets/thinking.py
+++ b/src/ui/widgets/thinking.py
@@ -1,0 +1,153 @@
+from gi.repository import Gtk, GObject, Adw, GLib
+from .markuptextview import MarkupTextView
+
+class ThinkingWidget(Gtk.Box):
+    """
+    A widget that displays a "thinking" state with an animated spinner
+    and an expandable section revealing the step-by-step thinking process
+    in a TextView.
+    """
+    __gsignals__ = {
+        'thinking-started': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'thinking-stopped': (GObject.SignalFlags.RUN_FIRST, None, ()),
+    }
+
+    def __init__(self, **kwargs):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, **kwargs)
+        self.add_css_class("code")
+        self.add_css_class("card")
+        self.set_margin_top(10)
+        self.set_margin_end(10)
+        self._is_thinking = False
+
+        # --- UI Elements ---
+        self.expander = Adw.ExpanderRow(
+            title=_("Thoughts"),
+            subtitle=_("Expand to see details"),
+            show_enable_switch=False,
+            expanded=False # Start collapsed
+        )
+
+        self.spinner = Gtk.Spinner(
+            spinning=False,
+            visible=False # Hide initially
+        )
+        # Add spinner to the start of the expander row header
+        self.expander.add_prefix(self.spinner)
+
+        self.textview = MarkupTextView(
+            editable=False, # Read-only for the user
+            cursor_visible=False,
+            wrap_mode=Gtk.WrapMode.WORD_CHAR,
+            vexpand=True,
+            hexpand=True,
+            pixels_below_lines=5, # Add some spacing
+            left_margin=6,
+            right_margin=6,
+            top_margin=6,
+            bottom_margin=6,
+        )
+        self.textbuffer = self.textview.get_buffer()
+
+        scrolled_window = Gtk.ScrolledWindow(
+            hscrollbar_policy=Gtk.PolicyType.NEVER, # Hide horizontal scrollbar
+            vscrollbar_policy=Gtk.PolicyType.AUTOMATIC,
+            min_content_height=150, # Give it some minimum height when expanded
+            max_content_height=400, # And a maximum height
+            child=self.textview
+        )
+        scrolled_window.add_css_class("expander-inset-content") # Style hint
+
+        # Add the scrolled text view as the content of the expander row
+        self.expander.add_row(scrolled_window)
+
+        # Add the expander row to this Box widget
+        self.append(self.expander)
+
+
+    def start_thinking(self, initial_message=""):
+        """Starts the thinking process indication."""
+        if self._is_thinking:
+            return # Already thinking
+
+        self._is_thinking = True
+        # Use GLib.idle_add to ensure UI updates happen on the main thread
+        GLib.idle_add(self._update_ui_start_thinking, initial_message)
+        self.emit('thinking-started')
+
+    def stop_thinking(self, final_title="LLM Thought Process"):
+        """Stops the thinking process indication."""
+        if not self._is_thinking:
+            return # Not thinking
+
+        print("ThinkingWidget: Stopping thinking...")
+        self._is_thinking = False
+        # Use GLib.idle_add to ensure UI updates happen on the main thread
+        GLib.idle_add(self._update_ui_stop_thinking, final_title)
+        self.emit('thinking-stopped')
+
+    def append_thinking(self, text):
+        """Appends text to the thinking process TextView."""
+        if not self._is_thinking:
+            print("Warning: append_thinking called while not in thinking state.")
+
+        # Ensure UI updates happen on the main thread
+        GLib.idle_add(self._update_ui_append_text, text)
+
+    def set_thinking(self, text):
+        """Sets the entire thinking process text, replacing existing content."""
+        # Ensure UI updates happen on the main thread
+        GLib.idle_add(self._update_ui_set_text, text)
+
+
+    def clear_thinking(self):
+        """Clears the thinking text."""
+        GLib.idle_add(self.textbuffer.set_text, "", -1)
+
+    def is_thinking(self):
+        """Returns True if the widget is currently in the thinking state."""
+        return self._is_thinking
+
+    def _update_ui_start_thinking(self, initial_message):
+        self.spinner.set_visible(True)
+        self.spinner.start()
+        self.expander.set_title(_("Thinking..."))
+        self.expander.set_subtitle(_("The LLM is thinking... Expand to see thought process"))
+        self.textbuffer.set_text(initial_message, -1) # Clear and set initial text
+        self._scroll_to_end()
+        return GLib.SOURCE_REMOVE 
+
+    def _update_ui_stop_thinking(self, final_title):
+        self.spinner.stop()
+        self.spinner.set_visible(False)
+        self.expander.set_title(final_title)
+        if self.textbuffer.get_char_count() > 0:
+             self.expander.set_subtitle(_("Expand to see details"))
+        else:
+             self.expander.set_subtitle(_("No thought process recorded"))
+        return GLib.SOURCE_REMOVE # Remove the idle source
+
+    def _update_ui_append_text(self, text):
+        end_iter = self.textbuffer.get_end_iter()
+        self.textbuffer.insert(end_iter, text, -1)
+        # Auto-scroll to the end only if the user hasn't scrolled up manually
+        # A simple way is to always scroll for this example
+        self._scroll_to_end()
+        return GLib.SOURCE_REMOVE # Remove the idle source
+
+    def _update_ui_set_text(self, text):
+        self.textbuffer.set_text(text, -1)
+        # Scroll to the beginning after setting text
+        start_iter = self.textbuffer.get_start_iter()
+        self.textview.scroll_to_iter(start_iter, 0.0, False, 0.0, 0.0)
+        return GLib.SOURCE_REMOVE # Remove the idle source
+
+    def _scroll_to_end(self):
+        """Scrolls the TextView to the end."""
+        end_iter = self.textbuffer.get_end_iter()
+        # Mark ensures the view scrolls down even if text added rapidly
+        end_mark = self.textbuffer.create_mark("end_mark", end_iter, False)
+        self.textview.scroll_to_mark(end_mark, 0.0, True, 0.0, 1.0) # Align bottom
+        # Clean up the mark
+        GLib.idle_add(self.textbuffer.delete_mark, end_mark)
+

--- a/src/ui/widgets/thinking.py
+++ b/src/ui/widgets/thinking.py
@@ -18,6 +18,8 @@ class ThinkingWidget(Gtk.Box):
         self.add_css_class("card")
         self.set_margin_top(10)
         self.set_margin_end(10)
+        self.set_margin_bottom(5)
+        self.set_margin_start(5)
         self._is_thinking = False
 
         # --- UI Elements ---

--- a/src/utility/media.py
+++ b/src/utility/media.py
@@ -114,13 +114,14 @@ def extract_file(message: str) -> tuple[str | None, str]:
         text = message
     return file, text
 
-def extract_supported_files(history: list, supported_extensions: list) -> list[str]:
+def extract_supported_files(history: list, supported_extensions: list, blacklist_formats: list = []) -> list[str]:
     """
-    Extract supported files from message history
+    Extract supported files from message history, excluding blacklisted formats
 
     Args:
         history: message history
-        extensions: list of supported file extensions
+        supported_extensions: list of supported file extensions
+        blacklist_formats: list of file formats to exclude (optional)
 
     Returns:
         list[str]: list of supported files
@@ -134,7 +135,10 @@ def extract_supported_files(history: list, supported_extensions: list) -> list[s
                 for file in files:
                     if file.startswith("#"):
                         continue
-                    # Check if any pattern in supported_extensions matches the file name (case-insensitive)
+                    # Check if any supported extension matches
                     if any(fnmatch.fnmatch(file.lower(), pattern.lower()) for pattern in supported_extensions):
+                        # Check if file is in blacklist
+                        if any(fnmatch.fnmatch(file.lower(), pattern.lower()) for pattern in blacklist_formats):
+                            continue  # Skip if blacklisted
                         documents.append("file:" + file)
     return documents

--- a/src/window.py
+++ b/src/window.py
@@ -1935,6 +1935,9 @@ class MainWindow(Gtk.ApplicationWindow):
                 continue
             if self.controller.newelle_settings.remove_thinking:
                 msg["Message"] = remove_thinking_blocks(msg["Message"])
+            if msg["User"] == "File" or msg["User"] == "Folder":
+                msg["Message"] = f"```{msg['User'].lower()}\n{msg['Message'].strip()}\n```"
+                msg["User"] = "User"
             history.append(msg)
             count -= 1
         return history

--- a/src/window.py
+++ b/src/window.py
@@ -1058,13 +1058,18 @@ class MainWindow(Gtk.ApplicationWindow):
     def attach_file(self, button):
         """Show attach file dialog to add a file"""
         filters = Gio.ListStore.new(Gtk.FileFilter)
-
+        image_patterns = ["*.png", "*.jpg", "*.jpeg", "*.webp"]
+        video_patterns = ["*.mp4"]
+        file_patterns = self.model.get_supported_files()
+        rag_patterns = self.rag_handler.get_supported_files() if self.rag_handler is not None else []
+        supported_patterns = []
+            
         image_filter = Gtk.FileFilter(
-            name="Images", patterns=["*.png", "*.jpg", "*.jpeg", "*.webp"]
+            name=_("Images"), patterns=image_patterns
         )
-        video_filter = Gtk.FileFilter(name="Video", patterns=["*.mp4"])
+        video_filter = Gtk.FileFilter(name="Video", patterns=video_patterns)
         file_filter = Gtk.FileFilter(
-            name="Supported Files", patterns=self.model.get_supported_files()
+            name=_("LLM Supported Files"), patterns=file_patterns
         )
         second_file_filter = None
         if (
@@ -1072,23 +1077,28 @@ class MainWindow(Gtk.ApplicationWindow):
             and self.controller.newelle_settings.rag_on_documents
         ):
             second_file_filter = Gtk.FileFilter(
-                name="RAG Supported files",
+                name=_("RAG Supported files"),
                 patterns=self.rag_handler.get_supported_files(),
             )
+            supported_patterns += rag_patterns
         default_filter = None
+        
         if second_file_filter is not None:
             filters.append(second_file_filter)
-            default_filter = video_filter
         if self.model.supports_video_vision():
             filters.append(video_filter)
-            default_filter = video_filter
+            supported_patterns += video_patterns
         if len(self.model.get_supported_files()) > 0:
             filters.append(file_filter)
-            default_filter = file_filter
+            supported_patterns += file_patterns
         if self.model.supports_vision():
+            supported_patterns += image_patterns
             filters.append(image_filter)
-            default_filter = image_filter
-
+        default_filter = Gtk.FileFilter(
+            name=_("Supported Files"),
+            patterns=supported_patterns
+        )
+        filters.append(default_filter)
         dialog = Gtk.FileDialog(
             title=_("Attach file"),
             modal=True,

--- a/src/window.py
+++ b/src/window.py
@@ -1970,6 +1970,7 @@ class MainWindow(Gtk.ApplicationWindow):
             documents = extract_supported_files(
                 self.get_history(include_last_message=True),
                 self.rag_handler.get_supported_files(),
+                self.model.get_supported_files()
             )
             if len(documents) > 0:
                 r += self.rag_handler.query_document(

--- a/src/window.py
+++ b/src/window.py
@@ -2580,7 +2580,7 @@ class MainWindow(Gtk.ApplicationWindow):
                     label.set_opacity(0)
                     overlay.set_child(label)
                     # Create the textview
-                    textview = MarkupTextView(None)
+                    textview = MarkupTextView()
                     textview.set_valign(Gtk.Align.START)
                     textview.set_hexpand(True)
                     overlay.add_overlay(textview)


### PR DESCRIPTION
Fixes #97 
- For web search add our custom SearXNG instance by default
- Make files send via drag and drop readable for LLM
- Add a new Thinking widget
- Change defaut file filter to all supported files
- Add support for vision in Llama4 Groq
- Fix some issues with extensions widget introduced in the last PR
- Add the ability to read website content. If they are too long, RAG is used
- Improve the "regex" to get the website link from the message
- Don't use RAG on files supported by the LLM #175 
- Lower the default similarity for RAG as WordLlama usually gives low values


https://github.com/user-attachments/assets/411e4df8-bb9a-4518-987b-a36c7f1cd53a

