### PR TITLE
docs(metainfo): Add vcs-browser url

### DIFF
--- a/data/io.github.qwersyk.Newelle.appdata.xml.in
+++ b/data/io.github.qwersyk.Newelle.appdata.xml.in
@@ -23,11 +23,12 @@
 			<caption>More than 10 standard AI providers</caption>
 		</screenshot>
 	</screenshots>
-  <branding>
-    <color type="primary" scheme_preference="light">#99c1f1</color>
-    <color type="primary" scheme_preference="dark">#003d81</color>
-  </branding>
-	<url type="homepage">https://github.com/qwersyk/Newelle</url>
+  	<branding>
+    		<color type="primary" scheme_preference="light">#99c1f1</color>
+    		<color type="primary" scheme_preference="dark">#003d81</color>
+  	</branding>
+	<url type="homepage">https://github.com/qwersyk/Newelle/wiki</url>
+  	<url type="vcs-browser">https://github.com/qwersyk/Newelle</url>
 	<url type="bugtracker">https://github.com/qwersyk/Newelle/issues</url>
 	<content_rating type="oars-1.0" />
 	<releases>


### PR DESCRIPTION
and use wiki as homepage

cf. https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url