### PR TITLE
Minor fixes

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -403,7 +403,7 @@ AVAILABLE_PROMPTS = [
         "setting_name": "websearch",
         "editable": True,
         "show_in_settings": True,
-        "default": False
+        "default": True
     },
     {
         "key": "basic_functionality",

--- a/src/constants.py
+++ b/src/constants.py
@@ -106,7 +106,7 @@ AVAILABLE_STT = {
         "website": "https://github.com/ggerganov/whisper.cpp",
         "class": WhisperCPPHandler,
     },
-    "sphinx": {
+    "Sphinx": {
         "key": "sphinx",
         "title": _("CMU Sphinx"),
         "description": _("Works offline. Only English supported"),

--- a/src/controller.py
+++ b/src/controller.py
@@ -195,9 +195,10 @@ class NewelleController:
         elif reload_type == ReloadType.LLM:
             self.handlers.select_handlers(self.newelle_settings)
             threading.Thread(target=self.handlers.llm.load_model, args=(None,)).start()
-        elif reload_type == ReloadType.SECONDARY_LLM and self.newelle_settings.use_secondary_language_model:
+        elif reload_type == ReloadType.SECONDARY_LLM:
             self.handlers.select_handlers(self.newelle_settings)
-            threading.Thread(target=self.handlers.secondary_llm.load_model, args=(None,)).start()
+            if self.newelle_settings.use_secondary_language_model:
+                threading.Thread(target=self.handlers.secondary_llm.load_model, args=(None,)).start()
         elif reload_type in [ReloadType.TTS, ReloadType.STT, ReloadType.MEMORIES]:
             self.handlers.select_handlers(self.newelle_settings)
         elif reload_type == ReloadType.RAG:

--- a/src/controller.py
+++ b/src/controller.py
@@ -85,6 +85,7 @@ class NewelleController:
         self.settings = Gio.Settings.new(SCHEMA_ID)
         self.python_path = python_path
         self.ui_controller : UIController | None = None
+        self.installing_handlers = {}
 
     def ui_init(self):
         """Init necessary variables for the UI and load models and handlers"""
@@ -95,7 +96,7 @@ class NewelleController:
         self.newelle_settings = NewelleSettings()
         self.newelle_settings.load_settings(self.settings)
         self.load_chats(self.newelle_settings.chat_id)
-        self.handlers = HandlersManager(self.settings, self.extensionloader, self.models_dir, self.integrationsloader)
+        self.handlers = HandlersManager(self.settings, self.extensionloader, self.models_dir, self.integrationsloader, self.installing_handlers)
         self.handlers.select_handlers(self.newelle_settings)
         threading.Thread(target=self.handlers.cache_handlers).start()
 
@@ -474,7 +475,7 @@ class HandlersManager:
         memory: Memory Handler
         rag: RAG Handler 
     """
-    def __init__(self, settings: Gio.Settings, extensionloader : ExtensionLoader, models_path, integrations: ExtensionLoader):
+    def __init__(self, settings: Gio.Settings, extensionloader : ExtensionLoader, models_path, integrations: ExtensionLoader, installing_handlers: dict):
         self.settings = settings
         self.extensionloader = extensionloader
         self.directory = models_path
@@ -482,6 +483,7 @@ class HandlersManager:
         self.handlers_cached = threading.Semaphore()
         self.handlers_cached.acquire()
         self.integrationsloader = integrations
+        self.installing_handlers = installing_handlers
 
     def fix_handlers_integrity(self, newelle_settings: NewelleSettings):
         """Select available handlers if not available handlers in settings
@@ -533,7 +535,7 @@ class HandlersManager:
         self.integrationsloader.set_handlers(self.llm, self.stt, self.tts, self.secondary_llm, self.embedding, self.rag, self.memory, self.websearch)
         self.extensionloader.set_handlers(self.llm, self.stt, self.tts, self.secondary_llm, self.embedding, self.rag, self.memory, self.websearch)
         self.memory.set_handlers(self.secondary_llm, self.embedding)
-        
+
         self.rag.set_handlers(self.llm, self.embedding)
         threading.Thread(target=self.install_missing_handlers).start()
 
@@ -555,19 +557,18 @@ class HandlersManager:
             self.rag.load()
 
     def install_missing_handlers(self):
-        """Install selected handlers that are not installed. Assumes that select_handlers has been called"""
-        if not self.llm.is_installed():
-            self.llm.install()
-        if not self.stt.is_installed():
-            self.stt.install()
-        if not self.tts.is_installed():
-            self.tts.install()
-        if not self.embedding.is_installed():
-            self.embedding.install()
-        if not self.memory.is_installed():
-            self.memory.install()
-        if not self.rag.is_installed():
-            self.rag.install()
+        """Install selected handlers that are not installed. Assumes that select_handlers has been called""" 
+        handlers = [self.llm, self.stt, self.tts, self.memory, 
+                    self.embedding, self.rag, self.websearch]
+        for handler in handlers:
+            if not handler.is_installed():
+                self.set_installing(handler, True)
+                handler.install()
+                self.set_installing(handler, False)
+
+    def set_installing(self, handler: Handler, status: bool):
+        """Set installing status"""
+        self.installing_handlers[(handler.key, handler.schema_key)] = status
 
     def cache_handlers(self):
         """Cache handlers"""

--- a/src/handlers/llm/ollama_handler.py
+++ b/src/handlers/llm/ollama_handler.py
@@ -20,7 +20,7 @@ class OllamaHandler(LLMHandler):
     # Url where to get the available models info
     library_url = "https://nyarchlinux.moe/available_models.json"
     # List of models to be included in the library by default
-    listed_models = ["llama3.2-vision:11b", "deepseek-r1:1.5b", "deepseek-r1:7b", "deepseek-r1:14b", "llama3.2:3b", "llama3.1:8b", "qwq:32b", "qwen2.5:1.5b", "qwen2.5:3b", "qwen2.5:7b", "qwen2.5:14b", "gemma2:2b", "gemma2:9b", "qwen2.5-coder:3b", "qwen2.5-coder:7b", "qwen2.5-coder:14b", "llama3.3:70b", "phi4:14b"]
+    listed_models = ["qwen3:4b", "qwen3:8b", "deepseek-r1:8b", "qwen3:14b", "llama3.2-vision:11b", "deepseek-r1:1.5b", "deepseek-r1:7b", "deepseek-r1:14b", "llama3.2:3b", "llama3.1:8b", "qwq:32b", "qwen2.5:1.5b", "qwen2.5:3b", "qwen2.5:7b", "qwen2.5:14b", "gemma2:2b", "gemma2:9b", "qwen2.5-coder:3b", "qwen2.5-coder:7b", "qwen2.5-coder:14b", "llama3.3:70b", "phi4:14b"]
 
     def __init__(self, settings, path):
         super().__init__(settings, path)
@@ -149,6 +149,7 @@ class OllamaHandler(LLMHandler):
         settings = [
             ExtraSettings.EntrySetting("endpoint", _("API Endpoint"), _("API base url, change this to use interference APIs"), "http://localhost:11434"),
             ExtraSettings.ToggleSetting("serve", _("Automatically Serve"), _("Automatically run ollama serve in background when needed if it's not running. You can kill it with killall ollama"), False),
+            ExtraSettings.ToggleSetting("thinking", _("Enable Thinking"), _("Allow thinking in the model, only some models are supported"), True, website="https://ollama.com/search?c=thinking"),
             ExtraSettings.ToggleSetting("custom_model", _("Custom Model"), _("Use a custom model"), False, update_settings=True),
         ]
         if not self.get_setting("custom_model", False):
@@ -183,6 +184,7 @@ class OllamaHandler(LLMHandler):
                 )
             )
         settings.append(get_streaming_extra_setting())
+        settings.append(ExtraSettings.ButtonSetting("update", _("Update Ollama"), _("Update Ollama"), lambda x: self.install(), _("Update Ollama")))
         return settings
 
     def pull_model(self, model: str):
@@ -328,6 +330,8 @@ class OllamaHandler(LLMHandler):
     
     def generate_text(self, prompt: str, history: list[dict[str, str]] = [], system_prompt: list[str] = []) -> str:
         from ollama import Client
+        if self.get_setting("thinking") is False:
+            prompt = "/no_think\n" + prompt
         history.append({"User": "User", "Message": prompt})
         messages = self.convert_history(history, system_prompt)
 
@@ -347,6 +351,8 @@ class OllamaHandler(LLMHandler):
     
     def generate_text_stream(self, prompt: str, history: list[dict[str, str]] = [], system_prompt: list[str] = [], on_update: Callable[[str], Any] = lambda _: None, extra_args: list = []) -> str:
         from ollama import Client
+        if self.get_setting("thinking") is False:
+            prompt = "/no_think\n" + prompt
         history.append({"User": "User", "Message": prompt})
         messages = self.convert_history(history, system_prompt)
         client = Client(
@@ -358,7 +364,7 @@ class OllamaHandler(LLMHandler):
             response = client.chat(
                 model=self.get_setting("model"),
                 messages=messages,
-                stream=True
+                stream=True,
             )
             full_message = ""
             prev_message = ""

--- a/src/handlers/llm/ollama_handler.py
+++ b/src/handlers/llm/ollama_handler.py
@@ -44,6 +44,7 @@ class OllamaHandler(LLMHandler):
 
     def get_models_list(self):
         return self.models
+
     def get_models_infomation(self):
         """Get information about models on ollama.com"""
         if self.is_installed(): 
@@ -178,7 +179,7 @@ class OllamaHandler(LLMHandler):
                             refresh_icon="plus-symbolic",
                             website="https://ollama.com/library"
                         )
-                    ] + self.get_model_library(), refresh=self.get_models_infomation
+                    ] + self.get_model_library(), refresh=lambda x : self.get_models_infomation
                 )
             )
         settings.append(get_streaming_extra_setting())

--- a/src/handlers/memory/user_summary_handler.py
+++ b/src/handlers/memory/user_summary_handler.py
@@ -2,6 +2,7 @@ from ...handlers.llm import LLMHandler
 from ...handlers.embeddings import EmbeddingHandler
 from .memory_handler import MemoryHandler
 from ...handlers import ExtraSettings
+from ...utility.strings import remove_thinking_blocks
 
 class UserSummaryHandler(MemoryHandler):
     key = "user-summary"
@@ -58,5 +59,6 @@ Only output the summary with no other details.
         if len(self.seen_messages) % update_frequency == 0:
             prompt = PROMPT.format(history="\n".join([i["User"] + ": " + i["Message"] for i in history[-update_frequency-2:]]), summary=self.get_setting("user_summary"))
             upd = self.llm.generate_text(prompt)
+            upd = remove_thinking_blocks(upd)
             self.set_setting("user_summary", upd)
         self.set_setting("seen_messages", self.seen_messages)

--- a/src/handlers/stt/sphinx_handler.py
+++ b/src/handlers/stt/sphinx_handler.py
@@ -2,7 +2,7 @@ import speech_recognition as sr
 from .stt import STTHandler
 
 class SphinxHandler(STTHandler):
-    key = "Sphinx"
+    key = "sphinx"
     
     @staticmethod
     def get_extra_requirements() -> list:

--- a/src/handlers/tts/kokoro_handler.py
+++ b/src/handlers/tts/kokoro_handler.py
@@ -1,11 +1,15 @@
+from os import walk
+import subprocess
 from .tts import TTSHandler
 from ...utility.pip import install_module, find_module
 from ..handler import ErrorSeverity
+from ...handlers import ExtraSettings
 
 class KokoroTTSHandler(TTSHandler):
     key = "kokoro"
     def install(self):
-        install_module("kokoro==0.8.4 soundfile", self.pip_path)
+        extra_deps = "pyopenjtalk fugashi jaconv mojimoji mecab-python3 unidic-lite"
+        install_module("kokoro==0.9.4 soundfile espeakng-loader " + extra_deps, self.pip_path)
         if not self.is_installed():
             self.throw("Kokoro installation failed", ErrorSeverity.ERROR)
 
@@ -17,11 +21,14 @@ class KokoroTTSHandler(TTSHandler):
         voices += "am_adam, am_echo, am_eric, am_fenrir, am_liam, am_michael, am_onyx, am_puck".split(", ")
         voices += "bf_alice, bf_emma, bf_isabella, bf_lily, bm_daniel, bm_fable, bm_george, bm_lewis".split(", ")
         # Espeak required for non english to work
-        #voices += ["ff_siwis"]
-        #voices += "if_sara, im_nicola".split(", ")
-        #voices += "jf_alpha, jf_gongitsune, jf_nezumi, jf_tebukuro, jm_kumo".split(", ")
-        #voices += "zf_xiaobei, zf_xiaoni, zf_xiaoxiao, zf_xiaoyi, zm_yunjian, zm_yunxi, zm_yunxia, zm_yunyang".split(", ")
-        flags = {"a": "🇺🇸", "b": "🇬🇧", "f": "🇫🇷", "i": "🇮🇹", "j": "🇯🇵", "z": "🇨🇳"}
+        voices += ["ef_dora", "em_alex", "em_santa"]
+        voices += ["hf_alpha", "hf_beta", "hm_omega", "hm_psi"]
+        voices += ["ff_siwis"]
+        voices += "if_sara, im_nicola".split(", ")
+        voices += ["pf_dora", "pm_alex", "pm_santa"]
+        voices += "jf_alpha, jf_gongitsune, jf_nezumi, jf_tebukuro, jm_kumo".split(", ")
+        voices += "zf_xiaobei, zf_xiaoni, zf_xiaoxiao, zf_xiaoyi, zm_yunjian, zm_yunxi, zm_yunxia, zm_yunyang".split(", ")
+        flags = {"a": "🇺🇸", "b": "🇬🇧","e": "🇪🇸", "f": "🇫🇷", "h": "🇮🇳", "p": "🇧🇷", "i": "🇮🇹", "j": "🇯🇵", "z": "🇨🇳"}
         genders = {"m": "🚹", "f": "🚺"}
         v = tuple()
         for voice in voices:

--- a/src/main.py
+++ b/src/main.py
@@ -125,10 +125,7 @@ class MyApp(Adw.Application):
         action = Gio.SimpleAction.new("extension", None)
         action.connect('activate', self.extension_action)
         self.add_action(action)
-        action = Gio.SimpleAction.new("stdout_monitor", None)
-        action.connect('activate', self.stdout_monitor_action)
-        self.add_action(action)
-
+    
     def create_action(self, name, callback, shortcuts=None):
         action = Gio.SimpleAction.new(name, None)
         action.connect("activate", callback)

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import gettext
 import gi 
 gi.require_version('Gtk', '4.0')
 gi.require_version('GtkSource', '5')
@@ -124,6 +125,9 @@ class MyApp(Adw.Application):
         action = Gio.SimpleAction.new("extension", None)
         action.connect('activate', self.extension_action)
         self.add_action(action)
+        action = Gio.SimpleAction.new("stdout_monitor", None)
+        action.connect('activate', self.stdout_monitor_action)
+        self.add_action(action)
 
     def create_action(self, name, callback, shortcuts=None):
         action = Gio.SimpleAction.new(name, None)
@@ -185,6 +189,10 @@ class MyApp(Adw.Application):
             return True
         extension.connect("close-request", close) 
         extension.present()
+    
+    def stdout_monitor_action(self, *a):
+        """Show the stdout monitor dialog"""
+        self.win.show_stdout_monitor_dialog()
     
     def close_window(self, *a):
         if hasattr(self,"mini_win"):

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,7 @@ ui_sources = [
   'ui/shortcuts.py',
   'ui/mini_window.py',
   'ui/explorer.py',
+  'ui/stdout_monitor.py',
 ]
 
 widgets_sources = [
@@ -173,7 +174,8 @@ utility_sources = [
   'utility/profile_settings.py',
   'utility/audio_recorder.py',
   'utility/message_chunk.py',
-  'utility/website_scraper.py'
+  'utility/website_scraper.py',
+  'utility/stdout_capture.py',
 ]
 
 install_data(newelle_sources, install_dir: moduledir)

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -684,7 +684,7 @@ class Settings(Adw.PreferencesWindow):
             return
         if "website" in setting:
             wbbutton = self.create_web_button(setting["website"])
-            r.add_prefix(wbbutton)
+            r.add_suffix(wbbutton)
         if "folder" in setting:
             wbbutton = self.create_web_button(setting["folder"], folder=True)
             r.add_suffix(wbbutton)

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -863,7 +863,7 @@ class Settings(Adw.PreferencesWindow):
                 spinner = Gtk.Spinner(spinning=True)
                 actionbutton.set_child(spinner)
                 actionbutton.add_css_class("accent")
-                actionbutton.connect("clicked", lambda _ : self.app.win.show_stdout_monitor_dialog())
+                actionbutton.connect("clicked", lambda _ : self.app.win.show_stdout_monitor_dialog(self))
             else:
                 icon = Gtk.Image.new_from_gicon(Gio.ThemedIcon(name="folder-download-symbolic"))
                 actionbutton.connect("clicked", self.install_model, handler)
@@ -905,7 +905,7 @@ class Settings(Adw.PreferencesWindow):
         spinner = Gtk.Spinner(spinning=True)
         button.set_child(spinner)
         button.disconnect_by_func(self.install_model)
-        button.connect("clicked", lambda x : self.app.win.show_stdout_monitor_dialog())
+        button.connect("clicked", lambda x : self.app.win.show_stdout_monitor_dialog(self))
         t = threading.Thread(target=self.install_model_async, args= (button, handler))
         t.start() 
 

--- a/src/ui/stdout_monitor.py
+++ b/src/ui/stdout_monitor.py
@@ -1,0 +1,305 @@
+import gettext
+from gi.repository import Gtk, Adw, Gio, Gdk, GLib
+from ..utility.stdout_capture import StdoutMonitor
+
+# Add gettext function
+_ = gettext.gettext
+
+
+class StdoutMonitorDialog:
+    """Dialog for monitoring stdout output in real-time with terminal interface"""
+    
+    def __init__(self, parent_window):
+        self.parent_window = parent_window
+        self.dialog = None
+        self.stdout_monitor = None
+        self.stdout_buffer = ""
+        self.stdout_textview = None
+        self.stdout_buffer_obj = None
+        self.stdout_status_label = None
+        self.stdout_line_count_label = None
+        self.stdout_toggle_button = None
+        
+    def show_dialog(self):
+        """Create and show the stdout monitor dialog"""
+        if self.dialog is not None:
+            self.dialog.present()
+            return
+            
+        # Create the dialog
+        self.dialog = Adw.Dialog()
+        self.dialog.set_title(_("Program Output Monitor"))
+        self.dialog.set_content_width(800)
+        self.dialog.set_content_height(600)
+        self.dialog.set_can_close(True)
+        
+        # Create main content box
+        content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        
+        # Header bar
+        header_bar = Adw.HeaderBar(css_classes=["flat"])
+        header_bar.set_title_widget(Gtk.Label(label=_("Program Output Monitor")))
+        
+        # Clear button
+        clear_button = Gtk.Button(
+            icon_name="edit-clear-all-symbolic",
+            css_classes=["flat"]
+        )
+        clear_button.set_tooltip_text(_("Clear output"))
+        clear_button.connect("clicked", self._clear_stdout_buffer)
+        header_bar.pack_start(clear_button)
+        
+        # Toggle monitoring button
+        # Check if monitoring is already active to set initial state
+        is_already_monitoring = self.stdout_monitor and self.stdout_monitor.is_active()
+        
+        self.stdout_toggle_button = Gtk.ToggleButton(
+            icon_name="media-playback-stop-symbolic" if is_already_monitoring else "media-playback-start-symbolic",
+            css_classes=["destructive-action"] if is_already_monitoring else ["suggested-action"],
+            active=is_already_monitoring
+        )
+        self.stdout_toggle_button.set_tooltip_text(_("Start/Stop monitoring"))
+        self.stdout_toggle_button.connect("toggled", self._toggle_stdout_monitoring)
+        header_bar.pack_end(self.stdout_toggle_button)
+        
+        content_box.append(header_bar)
+        
+        # Create terminal-like text view
+        stdout_scrolled = Gtk.ScrolledWindow()
+        stdout_scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        stdout_scrolled.set_vexpand(True)
+        stdout_scrolled.set_hexpand(True)
+        
+        self.stdout_textview = Gtk.TextView(
+            editable=False,
+            monospace=True,
+            wrap_mode=Gtk.WrapMode.WORD_CHAR,
+            css_classes=["terminal-output"]
+        )
+        
+        # Style the text view to look like a terminal
+        self._apply_terminal_styling()
+        
+        self.stdout_buffer_obj = self.stdout_textview.get_buffer()
+        
+        # If we have accumulated buffer content, display it immediately
+        if hasattr(self, '_accumulated_buffer') and self._accumulated_buffer:
+            self.stdout_buffer_obj.set_text(self._accumulated_buffer)
+            # Update line count
+            line_count = self.stdout_buffer_obj.get_line_count()
+            # We'll set this label shortly, but store the count for now
+            self._initial_line_count = line_count
+        else:
+            self._initial_line_count = 0
+        
+        stdout_scrolled.set_child(self.stdout_textview)
+        content_box.append(stdout_scrolled)
+        
+        # Status bar
+        status_box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=6,
+            margin_start=12,
+            margin_end=12,
+            margin_top=6,
+            margin_bottom=6
+        )
+        
+        self.stdout_status_label = Gtk.Label(
+            label=_("Monitoring: Active") if is_already_monitoring else _("Monitoring: Stopped"),
+            css_classes=["caption"]
+        )
+        status_box.append(self.stdout_status_label)
+        
+        # Line count label
+        self.stdout_line_count_label = Gtk.Label(
+            label=_("Lines: {}").format(self._initial_line_count),
+            css_classes=["caption"],
+            halign=Gtk.Align.END,
+            hexpand=True
+        )
+        status_box.append(self.stdout_line_count_label)
+        
+        content_box.append(status_box)
+        
+        self.dialog.set_child(content_box)
+        
+        # Connect dialog close event
+        self.dialog.connect("closed", self._on_dialog_closed)
+        
+        # If monitoring is already active, start the display update timer
+        if is_already_monitoring:
+            GLib.timeout_add(100, self._update_stdout_display)
+        
+        # Auto-scroll to bottom if there's existing content
+        if hasattr(self, '_accumulated_buffer') and self._accumulated_buffer:
+            GLib.idle_add(self._scroll_to_bottom)
+        
+        # Present the dialog
+        self.dialog.present()
+    
+    def _apply_terminal_styling(self):
+        """Apply terminal-like styling to the text view"""
+        css_provider = Gtk.CssProvider()
+        css_data = """
+        .terminal-output {
+            background-color: #1e1e1e;
+            color: #ffffff;
+            font-family: 'DejaVu Sans Mono', 'Consolas', 'Liberation Mono', monospace;
+            font-size: 11pt;
+            padding: 12px;
+        }
+        
+        .terminal-output text {
+            background-color: #1e1e1e;
+            color: #ffffff;
+        }
+        
+        .terminal-output:focus {
+            outline: none;
+            box-shadow: none;
+        }
+        """
+        
+        css_provider.load_from_data(css_data.encode())
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+    
+    def _toggle_stdout_monitoring(self, button):
+        """Toggle stdout monitoring on/off"""
+        if button.get_active():
+            self._start_stdout_monitoring()
+        else:
+            self._stop_stdout_monitoring()
+    
+    def _start_stdout_monitoring(self):
+        """Start monitoring stdout"""
+        if self.stdout_monitor and self.stdout_monitor.is_active():
+            # Monitoring is already active, just update UI and start display timer
+            if self.stdout_status_label:
+                self.stdout_status_label.set_label(_("Monitoring: Active"))
+            if self.stdout_toggle_button:
+                self.stdout_toggle_button.set_icon_name("media-playback-stop-symbolic")
+                self.stdout_toggle_button.remove_css_class("suggested-action")
+                self.stdout_toggle_button.add_css_class("destructive-action")
+            # Start the update timer if dialog is shown
+            GLib.timeout_add(100, self._update_stdout_display)
+            return
+            
+        self.stdout_status_label.set_label(_("Monitoring: Active"))
+        self.stdout_toggle_button.set_icon_name("media-playback-stop-symbolic")
+        self.stdout_toggle_button.remove_css_class("suggested-action")
+        self.stdout_toggle_button.add_css_class("destructive-action")
+        
+        # Create stdout monitor
+        self.stdout_monitor = StdoutMonitor(self._on_stdout_received)
+        self.stdout_monitor.start_monitoring()
+        
+        # Start the update timer
+        GLib.timeout_add(100, self._update_stdout_display)
+    
+    def _stop_stdout_monitoring(self):
+        """Stop monitoring stdout"""
+        if not self.stdout_monitor or not self.stdout_monitor.is_active():
+            return
+            
+        self.stdout_status_label.set_label(_("Monitoring: Stopped"))
+        self.stdout_toggle_button.set_icon_name("media-playback-start-symbolic")
+        self.stdout_toggle_button.remove_css_class("destructive-action")
+        self.stdout_toggle_button.add_css_class("suggested-action")
+        
+        # Stop the monitor
+        if self.stdout_monitor:
+            self.stdout_monitor.stop_monitoring()
+    
+    def _on_stdout_received(self, text):
+        """Callback when new stdout text is received"""
+        self.stdout_buffer += text
+        
+        # Also accumulate in a persistent buffer for when dialog is not shown
+        if not hasattr(self, '_accumulated_buffer'):
+            self._accumulated_buffer = ""
+        self._accumulated_buffer += text
+        
+        # Limit accumulated buffer size to prevent memory issues
+        if len(self._accumulated_buffer) > 100000:  # 100KB limit
+            # Keep only the last 80KB
+            self._accumulated_buffer = self._accumulated_buffer[-80000:]
+    
+    def _update_stdout_display(self):
+        """Update the display with new stdout content"""
+        if not self.stdout_monitor or not self.stdout_monitor.is_active():
+            return False
+            
+        if self.stdout_buffer and self.stdout_buffer_obj:
+            # Get the end iterator
+            end_iter = self.stdout_buffer_obj.get_end_iter()
+            
+            # Insert the new text
+            self.stdout_buffer_obj.insert(end_iter, self.stdout_buffer)
+            
+            # Clear the buffer
+            self.stdout_buffer = ""
+            
+            # Auto-scroll to bottom
+            mark = self.stdout_buffer_obj.get_insert()
+            self.stdout_textview.scroll_mark_onscreen(mark)
+            
+            # Update line count
+            line_count = self.stdout_buffer_obj.get_line_count()
+            self.stdout_line_count_label.set_label(_("Lines: {}").format(line_count))
+            
+            # Limit buffer size to prevent memory issues
+            if line_count > 1000:
+                start_iter = self.stdout_buffer_obj.get_start_iter()
+                # Remove first 200 lines
+                line_200_iter = self.stdout_buffer_obj.get_iter_at_line(200)
+                self.stdout_buffer_obj.delete(start_iter, line_200_iter)
+        
+        return True  # Continue the timer
+    
+    def _clear_stdout_buffer(self, button):
+        """Clear the stdout display buffer"""
+        if self.stdout_buffer_obj:
+            self.stdout_buffer_obj.set_text("")
+            self.stdout_line_count_label.set_label(_("Lines: 0"))
+        self.stdout_buffer = ""
+        # Also clear the accumulated buffer
+        if hasattr(self, '_accumulated_buffer'):
+            self._accumulated_buffer = ""
+    
+    def _on_dialog_closed(self, dialog):
+        """Handle dialog close event"""
+        # Don't stop monitoring when dialog is closed - let it continue in background
+        # Only reset the dialog reference
+        self.dialog = None
+    
+    def close(self):
+        """Close the dialog"""
+        if self.dialog:
+            self.dialog.close()
+    
+    def is_open(self):
+        """Check if the dialog is currently open"""
+        return self.dialog is not None
+    
+    def stop_monitoring_external(self):
+        """Stop monitoring when called externally (e.g., on app shutdown)"""
+        if self.stdout_monitor and self.stdout_monitor.is_active():
+            self.stdout_monitor.stop_monitoring()
+    
+    def is_monitoring_active(self):
+        """Check if stdout monitoring is currently active"""
+        return self.stdout_monitor and self.stdout_monitor.is_active()
+    
+    def _scroll_to_bottom(self):
+        """Scroll the text view to the bottom"""
+        if self.stdout_buffer_obj and self.stdout_textview:
+            # Get the end mark and scroll to it
+            end_iter = self.stdout_buffer_obj.get_end_iter()
+            end_mark = self.stdout_buffer_obj.create_mark(None, end_iter, False)
+            self.stdout_textview.scroll_mark_onscreen(end_mark)
+            self.stdout_buffer_obj.delete_mark(end_mark) 

--- a/src/ui/stdout_monitor.py
+++ b/src/ui/stdout_monitor.py
@@ -125,8 +125,7 @@ class StdoutMonitorDialog:
         self.dialog.set_child(content_box)
         
         # Connect dialog close event
-        self.dialog.connect("closed", self._on_dialog_closed)
-        
+        self.dialog.connect("closed", self._on_dialog_closed) 
         # If monitoring is already active, start the display update timer
         if is_already_monitoring:
             GLib.timeout_add(100, self._update_stdout_display)
@@ -275,7 +274,10 @@ class StdoutMonitorDialog:
         """Handle dialog close event"""
         # Don't stop monitoring when dialog is closed - let it continue in background
         # Only reset the dialog reference
-        self.dialog = None
+        if self.dialog is not None:
+            self.dialog.close()
+            self.dialog = None
+        return False
     
     def close(self):
         """Close the dialog"""

--- a/src/ui/stdout_monitor.py
+++ b/src/ui/stdout_monitor.py
@@ -7,11 +7,11 @@ _ = gettext.gettext
 
 
 class StdoutMonitorDialog:
-    """Dialog for monitoring stdout output in real-time with terminal interface"""
+    """Window for monitoring stdout output in real-time with terminal interface"""
     
     def __init__(self, parent_window):
         self.parent_window = parent_window
-        self.dialog = None
+        self.window = None
         self.stdout_monitor = None
         self.stdout_buffer = ""
         self.stdout_textview = None
@@ -20,18 +20,18 @@ class StdoutMonitorDialog:
         self.stdout_line_count_label = None
         self.stdout_toggle_button = None
         
-    def show_dialog(self):
-        """Create and show the stdout monitor dialog"""
-        if self.dialog is not None:
-            self.dialog.present()
+    def show_window(self):
+        """Create and show the stdout monitor window"""
+        if self.window is not None:
+            self.window.present()
             return
             
-        # Create the dialog
-        self.dialog = Adw.Dialog()
-        self.dialog.set_title(_("Program Output Monitor"))
-        self.dialog.set_content_width(800)
-        self.dialog.set_content_height(600)
-        self.dialog.set_can_close(True)
+        # Create the window
+        self.window = Gtk.Window()
+        self.window.set_title(_("Program Output Monitor"))
+        self.window.set_default_size(800, 600)
+        self.window.set_transient_for(self.parent_window)
+        self.window.set_modal(False)
         
         # Create main content box
         content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -122,10 +122,10 @@ class StdoutMonitorDialog:
         
         content_box.append(status_box)
         
-        self.dialog.set_child(content_box)
+        self.window.set_child(content_box)
         
-        # Connect dialog close event
-        self.dialog.connect("closed", self._on_dialog_closed) 
+        # Connect window close event
+        self.window.connect("close-request", self._on_window_close_request) 
         # If monitoring is already active, start the display update timer
         if is_already_monitoring:
             GLib.timeout_add(100, self._update_stdout_display)
@@ -134,8 +134,8 @@ class StdoutMonitorDialog:
         if hasattr(self, '_accumulated_buffer') and self._accumulated_buffer:
             GLib.idle_add(self._scroll_to_bottom)
         
-        # Present the dialog
-        self.dialog.present()
+        # Present the window
+        self.window.present()
     
     def _apply_terminal_styling(self):
         """Apply terminal-like styling to the text view"""
@@ -270,23 +270,23 @@ class StdoutMonitorDialog:
         if hasattr(self, '_accumulated_buffer'):
             self._accumulated_buffer = ""
     
-    def _on_dialog_closed(self, dialog):
-        """Handle dialog close event"""
-        # Don't stop monitoring when dialog is closed - let it continue in background
-        # Only reset the dialog reference
-        if self.dialog is not None:
-            self.dialog.close()
-            self.dialog = None
+    def _on_window_close_request(self, window):
+        """Handle window close event"""
+        # Don't stop monitoring when window is closed - let it continue in background
+        # Only reset the window reference
+        if self.window is not None:
+            self.window.close()
+            self.window = None
         return False
     
     def close(self):
-        """Close the dialog"""
-        if self.dialog:
-            self.dialog.close()
+        """Close the window"""
+        if self.window:
+            self.window.close()
     
     def is_open(self):
-        """Check if the dialog is currently open"""
-        return self.dialog is not None
+        """Check if the window is currently open"""
+        return self.window is not None
     
     def stop_monitoring_external(self):
         """Stop monitoring when called externally (e.g., on app shutdown)"""

--- a/src/utility/stdout_capture.py
+++ b/src/utility/stdout_capture.py
@@ -1,0 +1,122 @@
+import os
+import sys
+import threading
+import select
+from gi.repository import GLib
+
+
+class StdoutCapture:
+    """Custom stdout capture class that forwards output to original stdout and callback"""
+    
+    def __init__(self, callback):
+        self.callback = callback
+        self.original_stdout = sys.__stdout__
+    
+    def write(self, text):
+        # Forward to original stdout
+        self.original_stdout.write(text)
+        self.original_stdout.flush()
+        
+        # Send to callback for monitoring
+        if self.callback:
+            GLib.idle_add(self.callback, text)
+        
+        return len(text)
+    
+    def flush(self):
+        self.original_stdout.flush()
+    
+    def isatty(self):
+        return self.original_stdout.isatty()
+
+
+class StdoutMonitor:
+    """File descriptor level stdout monitor that captures subprocess output"""
+    
+    def __init__(self, callback):
+        self.callback = callback
+        self.active = False
+        self.stdout_read_fd = None
+        self.stdout_write_fd = None
+        self.original_stdout_fd = None
+        self.monitor_thread = None
+    
+    def start_monitoring(self):
+        """Start monitoring stdout at file descriptor level"""
+        if self.active:
+            return
+            
+        self.active = True
+        
+        # Create a pipe for capturing stdout at file descriptor level
+        self.stdout_read_fd, self.stdout_write_fd = os.pipe()
+        
+        # Save the original stdout file descriptor
+        self.original_stdout_fd = os.dup(1)  # 1 is stdout
+        
+        # Redirect stdout to our pipe
+        os.dup2(self.stdout_write_fd, 1)
+        
+        # Start a thread to read from the pipe and forward to both original stdout and our capture
+        self.monitor_thread = threading.Thread(target=self._monitor_stdout_fd, daemon=True)
+        self.monitor_thread.start()
+    
+    def stop_monitoring(self):
+        """Stop monitoring stdout"""
+        if not self.active:
+            return
+            
+        self.active = False
+        
+        # Restore the original stdout file descriptor
+        if self.original_stdout_fd is not None:
+            os.dup2(self.original_stdout_fd, 1)
+            os.close(self.original_stdout_fd)
+            self.original_stdout_fd = None
+        
+        # Close our pipe
+        if self.stdout_write_fd is not None:
+            os.close(self.stdout_write_fd)
+            self.stdout_write_fd = None
+        if self.stdout_read_fd is not None:
+            os.close(self.stdout_read_fd)
+            self.stdout_read_fd = None
+        
+        # Wait for monitoring thread to finish
+        if self.monitor_thread and self.monitor_thread.is_alive():
+            self.monitor_thread.join(timeout=1.0)
+            self.monitor_thread = None
+    
+    def _monitor_stdout_fd(self):
+        """Monitor the stdout file descriptor in a separate thread"""
+        try:
+            while self.active:
+                # Use select to check if data is available for reading
+                if self.stdout_read_fd is None:
+                    break
+                    
+                ready, _, _ = select.select([self.stdout_read_fd], [], [], 0.1)
+                
+                if ready:
+                    # Read data from our pipe
+                    try:
+                        data = os.read(self.stdout_read_fd, 4096)
+                        if data:
+                            text = data.decode('utf-8', errors='replace')
+                            
+                            # Write to original stdout so it still appears in terminal
+                            if self.original_stdout_fd is not None:
+                                os.write(self.original_stdout_fd, data)
+                            
+                            # Send to our capture buffer
+                            if self.callback:
+                                GLib.idle_add(self.callback, text)
+                    except OSError:
+                        # Pipe was closed
+                        break
+        except Exception as e:
+            print(f"Stdout monitoring error: {e}", file=sys.stderr)
+    
+    def is_active(self):
+        """Check if monitoring is currently active"""
+        return self.active 

--- a/src/utility/stdout_capture.py
+++ b/src/utility/stdout_capture.py
@@ -100,6 +100,8 @@ class StdoutMonitor:
                 if ready:
                     # Read data from our pipe
                     try:
+                        if self.original_stdout_fd is None:
+                            return
                         data = os.read(self.stdout_read_fd, 4096)
                         if data:
                             text = data.decode('utf-8', errors='replace')
@@ -115,7 +117,7 @@ class StdoutMonitor:
                         # Pipe was closed
                         break
         except Exception as e:
-            print(f"Stdout monitoring error: {e}", file=sys.stderr)
+            print("Error in stdout monitor: " + str(e))
     
     def is_active(self):
         """Check if monitoring is currently active"""

--- a/src/window.py
+++ b/src/window.py
@@ -1635,7 +1635,7 @@ class MainWindow(Adw.ApplicationWindow):
             self.send_button_start_spinner()
         elif self.last_error_box is not None:
             self.remove_error(True)
-            self.show_chat()
+            #self.show_chat()
             threading.Thread(target=self.send_message).start()
             self.send_button_start_spinner()
         else:
@@ -1654,7 +1654,10 @@ class MainWindow(Adw.ApplicationWindow):
         if not idle:
             GLib.idle_add(self.remove_error, True)
         if self.last_error_box is not None:
-            self.chat_list_block.remove(self.last_error_box)
+            error_row = self.chat_list_block.get_last_child()
+            if error_row is None:
+                return
+            self.chat_list_block.remove(error_row)
             self.last_error_box = None
 
     def update_history(self):

--- a/src/window.py
+++ b/src/window.py
@@ -579,6 +579,7 @@ class MainWindow(Adw.ApplicationWindow):
             {"title": _("Keyboard Shortcuts"), "subtitle": _("Control Newelle using Keyboard Shortcuts"), "on_click": lambda : self.app.on_shortcuts_action()},
             {"title": _("Prompt Control"), "subtitle": _("Newelle gives you 100% prompt control. Tune your prompts for your use."), "on_click": lambda : self.app.settings_action_paged("Prompts")},
             {"title": _("Thread Editing"), "subtitle": _("Check the programs and processes you run from Newelle"), "on_click": lambda : self.app.thread_editing_action()},
+            {"title": _("Programmable Prompts"), "subtitle": _("You can add dynamic prompts to Newelle, with conditions and probabilities"), "on_click": lambda : open_website("https://github.com/qwersyk/Newelle/wiki/Prompt-variables")},
         ]
         self.empty_chat_placeholder = Gtk.Box(hexpand=True, vexpand=True, orientation=Gtk.Orientation.VERTICAL)
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, halign=Gtk.Align.CENTER, valign=Gtk.Align.CENTER, spacing=20, vexpand=True)    

--- a/src/window.py
+++ b/src/window.py
@@ -3663,23 +3663,10 @@ class MainWindow(Adw.ApplicationWindow):
         self.stdout_monitor_dialog.stdout_monitor = StdoutMonitor(self.stdout_monitor_dialog._on_stdout_received)
         self.stdout_monitor_dialog.stdout_monitor.start_monitoring()
         
-        # Start the update timer for the background monitoring
-        GLib.timeout_add(10000, self._update_background_stdout)
-
-    def _update_background_stdout(self):
-        """Update stdout buffer in background even when dialog is not shown"""
-        if (self.stdout_monitor_dialog and 
-            self.stdout_monitor_dialog.stdout_monitor and 
-            self.stdout_monitor_dialog.stdout_monitor.is_active()):
-            # The buffer is automatically updated via the callback
-            return True
-        return False
-
     def show_stdout_monitor_dialog(self):
         """Create and show a dialog to monitor stdout in real-time with terminal interface"""
         if self.stdout_monitor_dialog is None:
             self._init_stdout_monitoring()
-        
         # Show the dialog and populate it with existing captured data
         self.stdout_monitor_dialog.show_dialog()
         

--- a/src/window.py
+++ b/src/window.py
@@ -3048,6 +3048,9 @@ class MainWindow(Adw.ApplicationWindow):
             wrap_mode=Pango.WrapMode.WORD,
             selectable=True,
             halign=Gtk.Align.START,
+            hexpand=True,
+            vexpand=True,
+            width_request=400
         )
         scroll = Gtk.ScrolledWindow(propagate_natural_width=True, height_request=600)
         scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)

--- a/src/window.py
+++ b/src/window.py
@@ -3663,12 +3663,15 @@ class MainWindow(Adw.ApplicationWindow):
         self.stdout_monitor_dialog.stdout_monitor = StdoutMonitor(self.stdout_monitor_dialog._on_stdout_received)
         self.stdout_monitor_dialog.stdout_monitor.start_monitoring()
         
-    def show_stdout_monitor_dialog(self):
+    def show_stdout_monitor_dialog(self, parent=None):
         """Create and show a dialog to monitor stdout in real-time with terminal interface"""
+        if parent is None:
+            parent = self
         if self.stdout_monitor_dialog is None:
             self._init_stdout_monitoring()
+        self.stdout_monitor_dialog.parent_window = parent
         # Show the dialog and populate it with existing captured data
-        self.stdout_monitor_dialog.show_dialog()
+        self.stdout_monitor_dialog.show_window()
         
         # If monitoring was already active, update the dialog's UI state
         if (self.stdout_monitor_dialog.stdout_monitor and 

--- a/src/window.py
+++ b/src/window.py
@@ -116,7 +116,6 @@ class MainWindow(Adw.ApplicationWindow):
         menu = Gio.Menu()
         menu.append(_("Thread editing"), "app.thread_editing")
         menu.append(_("Extensions"), "app.extension")
-        menu.append(_("Stdout Monitor"), "app.stdout_monitor")
         menu.append(_("Settings"), "app.settings")
         menu.append(_("Keyboard shorcuts"), "app.shortcuts")
         menu.append(_("About"), "app.about")


### PR DESCRIPTION
- Switch to ffplay for audio output, in order to avoid audio stop working after recording
- Add a new tip about programmable prompts
- Fix application crash after clicking "regenerate" 2 times after getting an error
- Show an error indicator when chat name generation fails
- Fix secondary LLM not updating under some circumstances
- Enable websearch prompt by default
- Add option to disable thinking in Ollama
- Remove thinking from user summary
- Update Kokoro and add additional languages support
- Add stdout monitor to check the program output while it's running
- Keep the install button spinning until it installs the program even if you close its window
- Clicking spinning install button opens the stdout monitor
- Added developer settings to open the stdout monitor and delete the pip path