### PR TITLE
nix: Add missing dependencies

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -12,11 +12,13 @@ desktopToDarwinBundle,
 vte-gtk4,
 dconf,
 gobject-introspection,
+glib-networking,
 gsettings-desktop-schemas,
 adwaita-icon-theme,
 gtksourceview5,
 desktop-file-utils,
-lsb-release
+lsb-release,
+webkitgtk_6_0
 }:
 
 let
@@ -40,6 +42,8 @@ let
     llama-index-core
     llama-index-readers-file
     pip-install-test
+    cssselect
+    markdownify
   ];
 in
   stdenv.mkDerivation rec {
@@ -74,6 +78,8 @@ in
         gtksourceview5
         desktop-file-utils
         lsb-release
+        webkitgtk_6_0
+        glib-networking
       ];
 
     preFixup = ''


### PR DESCRIPTION
Fix issue #288 

@mipmip Can you take a look ?

I add also this following packages:
- markdownify
  ```
    File "/nix/store/0l53lnvh6phrm994jhrrzbn11llp5czs-newelle-0.9.6/share/newelle/newelle/utility/website_scraper.py", line 66, in clean_html_to_markdown
      from markdownify import markdownify as md
  ModuleNotFoundError: No module named 'markdownify'
  ```

- cssselect
  ```
  Traceback (most recent call last):
    File "/nix/store/kjvgj2n3yn70hmjifg6y0bk9m4rf7jba-python3-3.12.10/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
      self.run()
    File "/nix/store/kjvgj2n3yn70hmjifg6y0bk9m4rf7jba-python3-3.12.10/lib/python3.12/threading.py", line 1012, in run
      self._target(*self._args, **self._kwargs)
    File "/nix/store/5sgqsrbr1zm3jkh7c8mlciyxpc62smlk-newelle-0.9.6/share/newelle/newelle/ui/widgets/browser.py", line 220, in download_favicon
      self.article.parse_article()
    File "/nix/store/5sgqsrbr1zm3jkh7c8mlciyxpc62smlk-newelle-0.9.6/share/newelle/newelle/utility/website_scraper.py", line 29, in parse_article
      self.article.parse()
    File "/nix/store/z6rf0fnwh9kqb0vzd5nicw8z7r5gmr28-python3.12-newspaper3k-0.2.8/lib/python3.12/site-packages/newspaper/article.py", line 224, in parse
      self.extractor.get_meta_description(self.clean_doc)
    File "/nix/store/z6rf0fnwh9kqb0vzd5nicw8z7r5gmr28-python3.12-newspaper3k-0.2.8/lib/python3.12/site-packages/newspaper/extractors.py", line 478, in get_meta_description
      return self.get_meta_content(doc, "meta[name=description]")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/nix/store/z6rf0fnwh9kqb0vzd5nicw8z7r5gmr28-python3.12-newspaper3k-0.2.8/lib/python3.12/site-packages/newspaper/extractors.py", line 437, in get_meta_content
      meta = self.parser.css_select(doc, metaname)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/nix/store/z6rf0fnwh9kqb0vzd5nicw8z7r5gmr28-python3.12-newspaper3k-0.2.8/lib/python3.12/site-packages/newspaper/parsers.py", line 43, in css_select
      return node.cssselect(selector)
             ^^^^^^^^^^^^^^^^^^^^^^^^
    File "/nix/store/c548xxn3mii8ncxldlfba70a0yna8cx9-python3.12-lxml-5.3.1/lib/python3.12/site-packages/lxml/html/__init__.py", line 408, in cssselect
      from lxml.cssselect import CSSSelector
    File "/nix/store/c548xxn3mii8ncxldlfba70a0yna8cx9-python3.12-lxml-5.3.1/lib/python3.12/site-packages/lxml/cssselect.py", line 14, in <module>
      raise ImportError(
  ImportError: cssselect does not seem to be installed. See https://pypi.org/project/cssselect/
  Exception in thread Thread-79 (download_favicon):
  Traceback (most recent call last):
    File "/nix/store/c548xxn3mii8ncxldlfba70a0yna8cx9-python3.12-lxml-5.3.1/lib/python3.12/site-packages/lxml/cssselect.py", line 12, in <module>
      import cssselect as external_cssselect
  ModuleNotFoundError: No module named 'cssselect'
  ```

-  glib-networking : Fix the "TLS support is not available" in builtin Web Browser

**Note** I not add gpt4all because i not see the python module on nixos search
