### PR TITLE
fix: resolve UnboundLocalError when opening settings with MCP servers

### DIFF
--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -356,7 +356,7 @@ class Settings(Adw.PreferencesWindow):
             tool_count = len(group_tools)
             group_row = Adw.ExpanderRow(
                 title=group_name,
-                subtitle=("{} tools").format(tool_count) if tool_count != 1 else _("1 tool")
+                subtitle=("{} tools").format(tool_count) if tool_count != 1 else "1 tool"
             )
             # Add folder icon to distinguish groups from individual tools
             group_icon = Gtk.Image(icon_name="folder-symbolic", css_classes=["dim-label"])


### PR DESCRIPTION
## Summary
- Fix crash when opening Settings after adding an MCP server
- The `_()` translation function was called on line 359 without being imported in the local scope
- This only affects tool groups with exactly 1 tool

## Error
```
UnboundLocalError: cannot access local variable '_' where it is not associated with a value
```

## Test plan
- [ ] Add an MCP server in Settings
- [ ] Close and reopen Settings
- [ ] Verify no crash occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)