### PR TITLE
Fix Japanese translation of "About" to "Newelleについて"

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -2126,7 +2126,7 @@ msgstr "キーボードショートカット"
 
 #: src/window.py:121
 msgid "About"
-msgstr "について"
+msgstr "Newelleについて"
 
 #: src/window.py:128 src/window.py:197
 msgid "Chat"


### PR DESCRIPTION
## Summary
Fix the Japanese translation of "About".

The previous translation was "について", which is unnatural when used alone in the UI.
It has been changed to "Newelleについて", which is a more natural label for an About section.

## Changes
- Change Japanese translation of "About"
  - について → Newelleについて